### PR TITLE
fix(macmatcher): fix a bug where vendor name was incorrect

### DIFF
--- a/wifiphisher/macmatcher.py
+++ b/wifiphisher/macmatcher.py
@@ -77,7 +77,8 @@ class MACMatcher(object):
 
         # try to find the vendor and if not found return unknown
         try:
-            return self._mac_to_vendor[mac_identifier]
+            vendor = self._mac_to_vendor[mac_identifier][0]
+            return vendor
         except KeyError:
             return "Unknown"
 


### PR DESCRIPTION
This patch fixes a bug where instead of the vendor name it would display a list which vendor was in.
![modified](https://cloud.githubusercontent.com/assets/25112506/23530692/de13912e-ff70-11e6-88a4-a99dc667e6ee.png)

I'm sorry for letting that bug through. My testing `virtualbox` is acting weired and I have do a fresh install on it :smile:.