### PR TITLE
fix(pywifiphisher): fix a bug where ap logo path was used with None

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -786,7 +786,9 @@ def run():
 
     template.merge_context({'APs': APs_context})
 
-    ap_logo_path = template.use_file(mac_matcher.get_vendor_logo_path(ap_mac))
+    # only get logo path if MAC address is present
+    if ap_mac:
+        ap_logo_path = template.use_file(mac_matcher.get_vendor_logo_path(ap_mac))
 
     template.merge_context({
         'target_ap_channel': args.channel or "",


### PR DESCRIPTION
This patch fixes bug #489 where logo path was requsted with a None MAC address. This problem only
occured when user is using the --essid option.