### PR TITLE
fix(pywifiphisher): temporary fix #489

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -750,8 +750,6 @@ def run():
             channel = access_point.get_channel()
             ap_mac = access_point.get_mac_address()
             enctype = access_point.get_encryption()
-            # TODO: must be removed after L1059 has been fixed
-            args.channel = channel
         else:
             shutdown()
     # get the correct template
@@ -790,13 +788,14 @@ def run():
     if ap_mac:
         ap_logo_path = template.use_file(mac_matcher.get_vendor_logo_path(ap_mac))
 
+    # TODO: temporary remove the ap vendor get vendor and logo path to fix #489
     template.merge_context({
-        'target_ap_channel': args.channel or "",
+        'target_ap_channel': channel or "",
         'target_ap_essid': essid or "",
         'target_ap_bssid': ap_mac or "",
         'target_ap_encryption': enctype or "",
-        'target_ap_vendor': mac_matcher.get_vendor_name(ap_mac) or "",
-        'target_ap_logo_path': ap_logo_path or ""
+        'target_ap_vendor': "",
+        'target_ap_logo_path': ""
     })
 
     # We want to set this now for hostapd. Maybe the interface was in "monitor"


### PR DESCRIPTION
This patch will temporary fix #489 by disabling template vendor and logo path. They will be enabled
again after a proper fix.