### PR TITLE
feat(pywifiphisher):remove timeinterval argument

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -61,11 +61,7 @@ def parse_args():
               "Example: -iI ppp0"
               )
     )
-    parser.add_argument(
-        "-t",
-        "--timeinterval",
-        help=("Choose the time interval between DEAUTH packets being sent")
-    )
+
     parser.add_argument(
         "-dP",
         "--deauthpackets",


### PR DESCRIPTION
This patch will remove the timeinterval argument from the command
line argument section of wifiphisher. It is deprecated and no
longer applies.