### PR TITLE
fix(phishinghttp):fix issue with html encoding

### DIFF
--- a/wifiphisher/common/phishinghttp.py
+++ b/wifiphisher/common/phishinghttp.py
@@ -50,7 +50,7 @@ class ReceiveCredsHandler(tornado.web.RequestHandler):
                            )
             log_file.close()
         global terminate, creds
-        creds.insert(0, repr(self.request.body))
+        creds.insert(0, repr(tornado.escape.url_unescape(self.request.body)))
         terminate = True
 
 


### PR DESCRIPTION
This patches fixes the issue where special characters such as @%$ would be returned as HTML encoded. Now they will be decoded so they would show it's intended character.

issue #504