### PR TITLE
fix(pywifiphisher):fix ouput window flickering

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -741,14 +741,14 @@ class WifiphisherEngine:
                                 # show the 5 most recent devices
                                 for client in deauthentication.get_clients()[-5:]:
                                     print client
-                        print term.move(9,0) + term.blue("DHCP Leases: ")
+                        print term.move(6,0) + term.blue("DHCP Leases: ")
                         if os.path.isfile('/var/lib/misc/dnsmasq.leases'):
                             proc = check_output(['tail', '-5', '/var/lib/misc/dnsmasq.leases'])
-                            print term.move(10,0) + proc
-                        print term.move(17,0) + term.blue("HTTP requests: ")
+                            print term.move(7,0) + proc
+                        print term.move(13,0) + term.blue("HTTP requests: ")
                         if os.path.isfile('/tmp/wifiphisher-webserver.tmp'):
                             proc = check_output(['tail', '-5', '/tmp/wifiphisher-webserver.tmp'])
-                            print term.move(18,0) + proc
+                            print term.move(14,0) + proc
                         if phishinghttp.terminate and args.quitonsuccess:
                             raise KeyboardInterrupt
         except KeyboardInterrupt:


### PR DESCRIPTION
The original cause of this bug is the use of hard coded values for row numbers as it would cause issues when the window size is less than the row number. This patch will not fix the above bug however it does ensure that the minimum number of rows are used to achieve the output.

issue #441 