### PR TITLE
fix(recon):error happening on ap selection

### DIFF
--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -174,11 +174,13 @@ class AccessPointFinder(object):
 
         # check the type of the packet
         if packet.haslayer(dot11.Dot11Beacon):
-            # if the packet has no info (hidden ap) add MAC address of
-            # it to the list otherwise get it's name and encryption
-            if not packet.info:
+            # if the packet has no info (hidden ap) add MAC address of it to the list
+            # note \00 used for when ap is hidden and shows only the length of the name
+            # see issue #506
+            if not packet.info or "\00" in packet.info:
                 if packet.addr3 not in self._hidden_networks:
                     self._hidden_networks.append(packet.addr3)
+            # otherwise get it's name and encryption
             else:
                 self._create_ap_with_info(packet)
 


### PR DESCRIPTION
This patch will fix the error in ap selection where it would cause a TypeError in the program. The cause of this error is the ap name when the ap in hidden. It only shows the number of bits in format "\00". Example if the name of the ap is HELLO it would show it as "\00\00\00\00\00".

issue #506 

See [this](https://github.com/wifiphisher/wifiphisher/issues/506#issuecomment-289305689) for more in depth explanation.