### PR TITLE
Fixed the bug for getting the channel# for a malformed beacon.

### DIFF
--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -212,7 +212,11 @@ class AccessPointFinder(object):
         """
 
         elt_section = packet[dot11.Dot11Elt]
-        channel = str(ord(packet[dot11.Dot11Elt:3].info))
+        try:
+            channel = str(ord(packet[dot11.Dot11Elt:3].info))
+        except (TypeError, IndexError):
+            return
+
         mac_address = packet.addr3
         name = None
         encryption_type = None


### PR DESCRIPTION
Dear Contributors,
I can reproduce the #545. It seems that wifiphisher cannot correctly handle the malformed beacon. 
The following is the sniffer from the air:

![malform_beacon](https://cloud.githubusercontent.com/assets/6182530/25129873/84ed0a68-2472-11e7-8af9-4da1eadf0bb2.gif)

And the following is that I use pdb to break when TypeError exception occur, and the addr2 and ssid is correctly mapped to the above sniffer:

![malform_beacon_code](https://cloud.githubusercontent.com/assets/6182530/25129918/b9f87b48-2472-11e7-8a80-5e72d0f36ef4.gif)

The solution now is returning when channel# is invalid. 

