### PR TITLE
fixed the malformed beacon frame which doesn't contain the info field

### DIFF
--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -199,6 +199,22 @@ class AccessPointFinder(object):
         elif packet.haslayer(dot11.Dot11):
             self._find_clients(packet)
 
+    def _parse_rssi(self, packet):
+        """
+        Parse the rssi info from the packet
+
+        :param self: An AccessPointFinder object
+        :param packet: A scapy.layers.RadioTap object
+        :type self: AccessPointFinder
+        :type packet: scapy.layers.RadioTap
+        :return: rssi
+        :rtype: int
+        """
+        tmp = ord(packet.notdecoded[-4:-3])
+        tmp1 = ord(packet.notdecoded[-2:-1])
+        rssi = -(256 - max(tmp, tmp1))
+        return rssi
+
     def _create_ap_with_info(self, packet):
         """
         Create and add an access point using the extracted information
@@ -223,7 +239,7 @@ class AccessPointFinder(object):
         non_decodable_name = "<contains non-printable chars>"
 
         # find the signal strength
-        rssi = -(256 - ord(packet.notdecoded[-4:-3]))
+        rssi = self._parse_rssi(packet)
         new_signal_strength = self._calculate_signal_strength(rssi)
 
         # get the name of the access point

--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -212,7 +212,11 @@ class AccessPointFinder(object):
         """
 
         elt_section = packet[dot11.Dot11Elt]
-        channel = str(ord(packet[dot11.Dot11Elt:3].info))
+        try:
+            channel = str(ord(packet[dot11.Dot11Elt:3].info))
+        except (TypeError, IndexError):
+            return
+
         mac_address = packet.addr3
         name = None
         encryption_type = None

--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -179,15 +179,17 @@ class AccessPointFinder(object):
 
         # check the type of the packet
         if packet.haslayer(dot11.Dot11Beacon):
-            # if the packet has no info (hidden ap) add MAC address of it to the list
-            # note \00 used for when ap is hidden and shows only the length of the name
-            # see issue #506
-            if not packet.info or "\00" in packet.info:
-                if packet.addr3 not in self._hidden_networks:
-                    self._hidden_networks.append(packet.addr3)
-            # otherwise get it's name and encryption
-            else:
-                self._create_ap_with_info(packet)
+            #check if the packet has info field to prevent processing malform beacon
+            if hasattr(packet.payload, 'info'):
+                # if the packet has no info (hidden ap) add MAC address of it to the list
+                # note \00 used for when ap is hidden and shows only the length of the name
+                # see issue #506
+                if not packet.info or "\00" in packet.info:
+                    if packet.addr3 not in self._hidden_networks:
+                        self._hidden_networks.append(packet.addr3)
+                # otherwise get it's name and encryption
+                else:
+                    self._create_ap_with_info(packet)
 
         # if packet is a probe response and it's hidden add the
         # access point


### PR DESCRIPTION

Another malformed beacon frame issue. The following is the sniffer capture and the pdb session:

![4](https://cloud.githubusercontent.com/assets/6182530/25474098/7d2e3858-2b64-11e7-86d9-694409fc1b04.gif)

The following is the screenshot of wifiphisher:

![5](https://cloud.githubusercontent.com/assets/6182530/25474183/d24c92bc-2b64-11e7-993f-03be804654c8.gif)


