### PR TITLE
Fixed exception for not waiting sniff thread done

### DIFF
--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -392,5 +392,4 @@ class NetworkManager(object):
         :return: None
         :rtype: None 
         """
-
         self.reset_ifaces_to_managed()

--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -340,8 +340,8 @@ class AccessPointFinder(object):
 
         :param self: An AccessPointFinder object
         :type self: AccessPointFinder
-        :return: None
-        :rtype: None
+        :return: An tuple of sniff and channel hop threads
+        :rtype: tuple
         """
 
         # start finding access points in a separate thread

--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -351,6 +351,7 @@ class AccessPointFinder(object):
         # start channel hopping in a separate thread
         channel_hop_thread = threading.Thread(target=self._channel_hop)
         channel_hop_thread.start()
+        return sniff_packets_thread, channel_hop_thread
 
     def stop_finding_access_points(self):
         """

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -770,6 +770,8 @@ class WifiphisherEngine:
                         if phishinghttp.terminate and args.quitonsuccess:
                             raise KeyboardInterrupt
         except KeyboardInterrupt:
+            if deauthentication != None:
+                deauthentication.on_exit()
             self.stop()
 
 

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -281,7 +281,8 @@ def select_access_point(screen, interface, mac_matcher):
     access_point_finder = recon.AccessPointFinder(interface)
     if args.lure10_capture:
         access_point_finder.capture_aps()
-    access_point_finder.find_all_access_points()
+    sniff_packet_thread, channel_hop_thread = access_point_finder.\
+            find_all_access_points()
 
     position = 1
     page_number = 1
@@ -347,10 +348,14 @@ def select_access_point(screen, interface, mac_matcher):
 
             # turn off access point discovery and return the result
             access_point_finder.stop_finding_access_points()
+            sniff_packet_thread.join()
+            channel_hop_thread.join()
             return access_points[position-1]
 
     # turn off access point discovery
     access_point_finder.stop_finding_access_points()
+    sniff_packet_thread.join()
+    channel_hop_thread.join()
 
 
 def key_movement(information):


### PR DESCRIPTION
When use the following command:
`wifiphisher -aI wlan0 -nJ -p oauth-login`
will occur the following exception:

![exception_for_not_waiting_sniff_thread_done](https://cloud.githubusercontent.com/assets/6182530/25556049/d928ee72-2d27-11e7-8677-5265f20959ff.png)

This is beacuse we don't wait the sniff thread done and just set the interface mode to managed from the monitor mode.
Though the functionality is not being affected, maybe we can fix it to remove the annoying trace stack.

Another thing is similarly when the user ends the wifiphisher, the deauth thread should also be wait for done.
