### PR TITLE
Support internet connection by wireless interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 language: python
 
+dist: trusty
+
 python:
   - "2.7"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/wifiphisher/wifiphisher.svg?branch=master)](https://travis-ci.org/wifiphisher/wifiphisher)
+[![Documentation Status](https://readthedocs.org/projects/wifiphisher/badge/?version=latest)](http://wifiphisher.readthedocs.io/en/latest/?badge=latest)
 ![Python Version](https://img.shields.io/badge/python-2.7-blue.svg)
 ![License](https://img.shields.io/badge/license-GPL-blue.svg)
 [![Chat IRC](https://img.shields.io/badge/chat-IRC-ff69b4.svg)](https://webchat.freenode.net/?channels=%23wifiphisher)

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
                "Intended Audience :: System Administrators",
                "Intended Audience :: Information Technology"]
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
-INSTALL_REQUIRES = ["PyRIC", "tornado", "blessings>=1.6"]
+INSTALL_REQUIRES = ["PyRIC", "tornado", "blessings>=1.6", "dbus-python"]
 
 
 # run setup

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     mock
     pyric
     pytest
+    dbus-python
 
 [testenv:docs]
 deps =

--- a/wifiphisher/common/constants.py
+++ b/wifiphisher/common/constants.py
@@ -45,3 +45,9 @@ P = '\033[35m'   # purple
 C = '\033[36m'   # cyan
 GR = '\033[37m'  # gray
 T = '\033[93m'   # tan
+
+#NM DBus Marcos
+NM_APP_PATH = 'org.freedesktop.NetworkManager'
+NM_MANAGER_OBJ_PATH = '/org/freedesktop/NetworkManager'
+NM_MANAGER_INTERFACE_PATH = 'org.freedesktop.NetworkManager'
+NM_DEV_INTERFACE_PATH = 'org.freedesktop.NetworkManager.Device'


### PR DESCRIPTION
@sophron @blackHatMonkey 

I'm trying to make this feature as simple as possible. I don't write to the NetworkManager configuration file if the device is in managed state. In case of the device in `managed` state, I'll raise exception and let the user either stop NetworkManager or specify device in `unmanaged` state in the NetworkManager.conf. Also remove the `airmon-ng` section as @blackHatMonkey suggestions, and I also think this is too violent too. Any Suggestion is appreciated :)