### PR TITLE
chore: add tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ before_install:
   - sudo apt-get install -y hostapd dnsmasq
 
 install:
-  - pip install pylint
+  - pip install pylint tox
   - python setup.py install
 
 script:
   - pylint --errors-only wifiphisher
+  - tox -e ALL
 
 branches:
   only:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv:py27]
+commands = py.test
+deps =
+    scapy
+    sphinx
+    mock
+    pyric
+    pytest
+
+[testenv:docs]
+deps =
+    sphinx
+    sphinx_rtd_theme
+changedir = docs
+
+commands = sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
Add the `tox.ini` file to run the test files as well as check the documentation build to make sure it compiles without any errors.