### PR TITLE
Fixed exception when repeatly choose the same interface

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -378,6 +378,21 @@ class TestNetworkManager(unittest.TestCase):
         message = "Failed to validate a valid interface"
         self.assertTrue(actual, message)
 
+    def test_is_interface_valid_invalid_interface_error(self):
+        """
+        Test is_interface_valid method when interface is already been chosen
+        """
+
+        interface_name = "wlan0"
+        interface_object = "Card Object"
+        adapter = interfaces.NetworkAdapter(interface_name, interface_object, self.mac_address)
+        self.network_manager._name_to_object[interface_name] = adapter
+        # mimic the card has been chosen
+        self.network_manager._active.add(interface_name)
+
+        with self.assertRaises(interfaces.InvalidInterfaceError):
+            self.network_manager.is_interface_valid(interface_name)
+
     def test_is_interface_valid_no_interface_error(self):
         """
         Tests is_interface_valid method when interface is non existent

--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -362,7 +362,8 @@ class NetworkManager(object):
         :type mode: str
         :return: True if interface is valid
         :rtype: bool
-        :raises InvalidInterfaceError: If the interface is invalid
+        :raises InvalidInterfaceError: If the interface is invalid or the interface
+        has been chosen in the set _active
         :raises InterfaceManagedByNetworkManagerError: If the card is managed and
                 is being used as deauth/ap mode
         .. note: The available modes are monitor, AP and internet
@@ -383,6 +384,11 @@ class NetworkManager(object):
                 raise InvalidInterfaceError(interface_name, mode)
             elif mode == "AP" and not interface_adapter.has_ap_mode:
                 raise InvalidInterfaceError(interface_name, mode)
+
+            # raise an error if interface is already in the _active set
+            if interface_name in self._active:
+                raise InvalidInterfaceError(interface_name)
+
             # add the valid card to _active set
             self._active.add(interface_name)
             return True


### PR DESCRIPTION
@blackHatMonkey I found that the command below will pass the check in  `is_valid_interface`:

`./wifiphisher -aI wlan0 -jI wlan0 -p oauth-login`

I also write a test case for this case.