### PR TITLE
Disable the NetworkManager by dbus when no internet access via it

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -157,6 +157,10 @@ class TestIsManagedByNetworkManager(unittest.TestCase):
         # setup network_manager object
         self.network_manager = mock.MagicMock()
         self.network_manager.GetDevices.return_value = ['wlan0', 'wlan1']
+        # setup for test enable_enable_network_manager
+        # Get returns the attribute of NetworkingEnabled
+        self.network_manager.Get.return_value = True
+        self.network_manager.Enable.return_value = None
 
         # setup device_0 object
         self.interface_0 = 'wlan0'
@@ -225,6 +229,20 @@ class TestIsManagedByNetworkManager(unittest.TestCase):
                 return self.device_proxy_1
 
         return bus_side_effect
+
+    @mock.patch('dbus.Interface')
+    @mock.patch('dbus.SystemBus')
+    def test_toggle_networking_has_disable_nm_true(
+            self, fake_bus, fake_interface):
+        """
+        Test enable_network_manager disabling the NetworkManager
+        """
+        fake_bus.return_value = self.bus
+        fake_interface.side_effect = self.get_interface()
+        # disable the network manager
+        interfaces.toggle_networking(False)
+        message = "function attr has_disable_nm should be true"
+        self.assertTrue(interfaces.toggle_networking.has_disable_nm, message)
 
     @mock.patch('dbus.Interface')
     @mock.patch('dbus.SystemBus')

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -552,6 +552,9 @@ class WifiphisherEngine:
         if os.geteuid():
             sys.exit('[' + R + '-' + W + '] Please run as root')
 
+        if not args.internetinterface:
+            interfaces.toggle_networking(False)
+
         self.network_manager.start()
 
         # TODO: We should have more checks here:


### PR DESCRIPTION
@sophron @blackHatMonkey 

When network manager is enabled and we don't use it to access internet I'll disable it and recover it when `network_manager.on_exit`

I also write a test case for it.

Fix #639 