### PR TITLE
Fixed format of deauth frame when --essid is used

### DIFF
--- a/wifiphisher/common/extensions.py
+++ b/wifiphisher/common/extensions.py
@@ -86,7 +86,8 @@ class ExtensionManager(object):
                                 self._interface, int(self._current_channel))
                             self._socket = linux.L2Socket(
                                 iface=self._interface)
-                            time.sleep(1)
+                            # extends the channel hopping time to sniff more frames
+                            time.sleep(3)
                         except BaseException:
                             continue
                     else:


### PR DESCRIPTION
@blackHatMonkey 
To review easily I create this PR in wifiphisher branch for #600.

Not only fixed the deauth frame format but also frenzily sends deauth frames to all the 2G channels
base on the @sophron's work : )