### PR TITLE
Introduce roguehostapd to fork the softAP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
                "Intended Audience :: System Administrators",
                "Intended Audience :: Information Technology"]
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
-INSTALL_REQUIRES = ["PyRIC", "tornado", "blessings>=1.6", "dbus-python"]
+INSTALL_REQUIRES = ["PyRIC", "tornado", "blessings>=1.6", "dbus-python", "roguehostapd"]
 
 
 # run setup

--- a/wifiphisher/common/tui.py
+++ b/wifiphisher/common/tui.py
@@ -586,11 +586,13 @@ class TuiMain(object):
         """
         Get the information from pywifiphisher and print them out
         :param self: A TuiMain object
-        :type self: TuiMain
         :param screen: A curses window object
-        :type screen: _curses.curses.window
         :param info: A namedtuple of printing information
+        :type self: TuiMain
+        :type screen: _curses.curses.window
         :type info: namedtuple
+        :return: None
+        :rtype: None
         """
 
         # setup curses
@@ -605,7 +607,9 @@ class TuiMain(object):
             # catch the exception when screen size is smaller than
             # the text length
             try:
-                self.display_info(screen, info)
+                is_done = self.display_info(screen, info)
+                if is_done:
+                    return
             except curses.error:
                 pass
 
@@ -672,17 +676,19 @@ class TuiMain(object):
         """
         Print the information of Victims on the terminal
         :param self: A TuiMain object
-        :type self: TuiMain
         :param screen: A curses window object
-        :type screen: _curses.curses.window
         :param info: A nameduple of printing information
+        :type self: TuiMain
+        :type screen: _curses.curses.window
         :type info: namedtuple
+        :return True if users have pressed the Esc key
+        :rtype: bool
         """
 
+        is_done = False
         screen.erase()
 
         _, max_window_length = screen.getmaxyx()
-
         # print the basic info on the right top corner
         screen.addstr(0, max_window_length - 30, "|")
         screen.addstr(1, max_window_length - 30, "|")
@@ -696,7 +702,9 @@ class TuiMain(object):
                       "|" + " Channel: " + info.channel)
         screen.addstr(4, max_window_length - 30,
                       "|" + " AP interface: " + info.ap_iface)
-        screen.addstr(5, max_window_length - 30, "|" + "_"*29)
+        screen.addstr(5, max_window_length - 30,
+                      "|" + " Options: [Esc] Quit")
+        screen.addstr(6, max_window_length - 30, "|" + "_"*29)
 
         # make Deauthenticating clients to blue color
         # print the deauthentication section
@@ -724,9 +732,15 @@ class TuiMain(object):
                                         '/tmp/wifiphisher-webserver.tmp'])
             self.print_http_requests(screen, 14, http_output)
 
+        # detect if users have pressed the Esc Key
+        if screen.getch() == 27:
+            is_done = True
+
         if info.phishinghttp.terminate and info.args.quitonsuccess:
-            raise KeyboardInterrupt
+            is_done = True
+
         screen.refresh()
+        return is_done
 
 
 def line_splitter(num_of_words, line):

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -764,6 +764,7 @@ class WifiphisherEngine:
                                      args)
             tui_main_object = tui.TuiMain()
             curses.wrapper(tui_main_object.gather_info, main_info)
+            self.stop()
         except KeyboardInterrupt:
             self.stop()
 


### PR DESCRIPTION
@sophron @blackHatMonkey 

This PR will add the following contents:
* Introduce the `roguehostapd`
* On the main terminal, I add an option `Esc` to leave the main terminal more gracefully.
* Add docstrings for the AccessPoint module.

The current `roguehostapd` on the PyPI may not work together with this PR, since we shut down the stdout in the `roguehostapd` module and we use threading for lauching hostapd which cause problems with the `curses section` in `wifiphisher`. 

I have committed to use the `mulitiprocess` in roguehostapd, and integrate it to `wifiphisher` works for me.