### PR TITLE
Support single interface to do deauth and ap in the same time

### DIFF
--- a/tests/test_deauth.py
+++ b/tests/test_deauth.py
@@ -20,7 +20,8 @@ class TestDeauth(unittest.TestCase):
         self.packet = dot11.RadioTap() / dot11.Dot11() / essid / rates / dsset
 
         custom_tuple = collections.namedtuple("test",
-                                              "target_ap_bssid target_ap_channel rogue_ap_mac args target_ap_essid")
+                                              ("target_ap_bssid target_ap_channel rogue_ap_mac args "
+                                               "target_ap_essid is_freq_hop_allowed"))
 
         self.target_channel = "6"
         self.target_bssid = "BB:BB:BB:BB:BB:BB"
@@ -30,9 +31,9 @@ class TestDeauth(unittest.TestCase):
         self.args.deauth_essid = False
 
         data0 = custom_tuple(self.target_bssid, self.target_channel, self.rogue_mac,
-                             self.args, self.target_essid)
+                             self.args, self.target_essid, True)
         data1 = custom_tuple(None, self.target_channel, self.rogue_mac,
-                             self.args, self.target_essid)
+                             self.args, self.target_essid, True)
 
         self.deauth_obj0 = deauth.Deauth(data0)
         self.deauth_obj1 = deauth.Deauth(data1)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -76,7 +76,7 @@ class TestExtensionManager(unittest.TestCase):
         # Init an EM and pass some shared data
         em = extensions.ExtensionManager(nm)
         em.set_extensions(constants.DEFAULT_EXTENSIONS)
-        shared_data = {"one": 1, "two": 2}
+        shared_data = {"one": 1, "two": 2, "is_freq_hop_allowed": True}
         em.init_extensions(shared_data)
         # A deauth packet appears in the air
         packet = (
@@ -107,7 +107,7 @@ class TestExtensionManager(unittest.TestCase):
         # Init an EM and pass some shared data
         em = extensions.ExtensionManager(nm)
         em.set_extensions(constants.DEFAULT_EXTENSIONS)
-        shared_data = {"one": 1, "two": 2}
+        shared_data = {"one": 1, "two": 2, "is_freq_hop_allowed": True}
         em.init_extensions(shared_data)
         # A deauth packet appears in the air
         packet = (

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1124,9 +1124,18 @@ class TestNetworkManager(unittest.TestCase):
         card = mock.Mock()
         pyric.down.return_value = None
         pyric.devadd.return_value = None
-        actual = interfaces.add_virtual_interface(card)
+        actual = self.network_manager.add_virtual_interface(card)
         expected = 'wlan1'
         self.assertEqual(actual, expected)
+
+    @mock.patch("wifiphisher.common.interfaces.pyw")
+    def test_remove_vifs_added(self, pyric):
+        card = mock.Mock()
+        self.network_manager._vifs_add = set()
+        self.network_manager._vifs_add.add(card)
+        pyric.devdel.return_value = None
+        self.network_manager.remove_vifs_added()
+        pyric.devdel.assert_called_once()
 
     @mock.patch("wifiphisher.common.interfaces.pyw")
     def test_add_virtual_interface_first_run_error_second_run_success(self, mock_pyric):
@@ -1146,7 +1155,7 @@ class TestNetworkManager(unittest.TestCase):
         mock_pyric.down.return_value = None
         mock_pyric.devadd.side_effect = side_effect
         expected = 'wlan2'
-        actual = interfaces.add_virtual_interface(card)
+        actual = self.network_manager.add_virtual_interface(card)
         self.assertEqual(actual, expected)
 
     @mock.patch("wifiphisher.common.interfaces.pyw")

--- a/wifiphisher/common/accesspoint.py
+++ b/wifiphisher/common/accesspoint.py
@@ -210,3 +210,6 @@ class AccessPoint(object):
             os.remove('/var/lib/misc/dnsmasq.leases')
         if os.path.isfile('/tmp/dhcpd.conf'):
             os.remove('/tmp/dhcpd.conf')
+        # sleep 2 seconds to wait all the hostapd process is
+        # killed
+        time.sleep(2)

--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -4,6 +4,7 @@ the program
 """
 
 import random
+from collections import defaultdict
 import pyric
 import pyric.pyw as pyw
 import dbus
@@ -425,9 +426,41 @@ class NetworkManager(object):
         if interface_name in self._active:
             raise InvalidInterfaceError(interface_name)
 
-        # add the valid card to _active set
         self._active.add(interface_name)
         return True
+
+    def up_interface(self, interface_name):
+        """
+        Equivalent to ifconfig interface_name up
+
+        :param self: A NetworkManager object
+        :param interface_name: Name of an interface
+        :type self: NetworkManager
+        :type interface_name: str
+        :return: None
+        :rtype: None
+        ..note: Let the pywifiphisher decide when to up the
+        interface since some cards cannot up two virtual interface
+        with managed mode in the same time.
+        """
+
+        card = self._name_to_object[interface_name].card
+        pyw.up(card)
+
+    def down_interface(self, interface_name):
+        """
+        Equivalent to ifconfig interface_name down
+
+        :param self: A NetworkManager object
+        :param interface_name: Name of an interface
+        :type self: NetworkManager
+        :type interface_name: str
+        :return: None
+        :rtype: None
+        """
+
+        card = self._name_to_object[interface_name].card
+        pyw.down(card)
 
     def set_interface_mac(self, interface_name, mac_address):
         """
@@ -443,15 +476,13 @@ class NetworkManager(object):
         :rtype: None
         .. note: This method will set the interface to managed mode
         """
-
         card = self._name_to_object[interface_name].card
         self.set_interface_mode(interface_name, "managed")
 
+        self.down_interface(interface_name)
         # card must be turned off(down) before setting mac address
         try:
-            pyw.down(card)
             pyw.macset(card, mac_address)
-            pyw.up(card)
         # make sure to catch an invalid mac address
         except pyric.error as error:
             if error[0] == 22:
@@ -485,6 +516,7 @@ class NetworkManager(object):
         :rtype: None
         .. note: This method will set the interface to managed mode.
             Also the first 3 octets are always 00:00:00 by default
+            Only set the mac address when card is in down state
         """
 
         # generate a new mac address and set it to adapter's new address
@@ -508,14 +540,13 @@ class NetworkManager(object):
         :rtype: None
         .. note: Available modes are unspecified, ibss, managed, AP
             AP VLAN, wds, monitor, mesh, p2p
+            Only set the mode when card is in the down state
         """
 
         card = self._name_to_object[interface_name].card
-
+        self.down_interface(interface_name)
         # set interface mode between brining it down and up
-        pyw.down(card)
         pyw.modeset(card, mode)
-        pyw.up(card)
 
     def get_interface(self, has_ap_mode=False, has_monitor_mode=False):
         """
@@ -658,6 +689,111 @@ class NetworkManager(object):
                 mac_address = adapter.original_mac_address
                 self.set_interface_mac(interface, mac_address)
 
+
+def add_virtual_interface(card):
+    """
+    Add the virtual interface to the host system
+    :param card: A pyw.Card object
+    :type card: pyw.Card
+    :return name of the interface
+    :rtype str
+    :..note: when add the interface it is possible raising the
+    pyric.error causing by adding the duplicated wlan interface
+    name.
+    """
+
+    done_flag = True
+    number = 0
+    while done_flag:
+        try:
+            number += 1
+            name = 'wlan' + str(number)
+            pyw.down(card)
+            pyw.devadd(card, name, 'monitor')
+            done_flag = False
+        # catch if wlan1 is already exist
+        except pyric.error:
+            pass
+    return name
+
+def is_add_vif_required(args):
+    """
+    Return the card if only that card support both monitor and ap
+    :param args: Arguemnt from pywifiphisher
+    :type args: parse.args
+    :return: tuple of card and is_frequency_hop_allowed
+    :rtype: tuple
+    """
+
+    def get_perfect_card(phy_map_vifs, vif_score_tups):
+        """
+        Get the perfect card that both supports ap and monitor when we
+        have only one phy interface can do that
+        :param phy_map_vifs: phy number maps to the virtual interfaces
+        :param vif_score_tups: list of tuple containing card and score
+        :type phy_map_vifs: dict
+        :type vif_score_tups: list
+        :return tuple of card and single_perfect_phy_case
+        :rtype: tuple
+        """
+        # case 1 : one phy maps to one virtual interface
+        if len(phy_map_vifs) == 1 and len(phy_map_vifs.values()[0]) == 1:
+            # only take the first tuple
+            vif_score_tuple = vif_score_tups[0]
+            card = vif_score_tuple[0]
+            score = vif_score_tuple[1]
+            # if this card support both monitor and AP mode
+            if score == 2:
+                return card, True
+        # case 2 : one phy maps to multiple virtual interfaces
+        # we don't need to create one more virtual interface in this case
+        elif len(phy_map_vifs) == 1 and len(phy_map_vifs.values()[0]) > 1:
+            return None, True
+        # case 3 : we have multiple phy interfaces but only
+        # one card support both monitor and AP and the other
+        # ones just support the managed mode only
+        elif len(phy_map_vifs) > 1:
+            if vif_score_tups[0][1] == 2 and vif_score_tups[1][1] == 0:
+                return vif_score_tups[0][0], True
+        return None, False
+
+    # map the phy interface to virtual interfaces
+    # i.e. phy0 to wlan0
+    phy_to_vifs = defaultdict(list)
+    # use to store the phy number for the internet access
+    invalid_phy_number = None
+    if args.internetinterface:
+        card = pyw.getcard(args.internetinterface)
+        invalid_phy_number = card.phy
+
+    # map the phy# to the virtual interface tuples
+    for vif in [vif for vif in pyw.interfaces() if pyw.iswireless(vif)]:
+        # excluding the card that used for internet accessing
+        # setup basic card information
+        score = 0
+        card = pyw.getcard(vif)
+        phy_number = card.phy
+        if phy_number == invalid_phy_number:
+            continue
+
+        supported_modes = pyw.devmodes(card)
+
+        if "monitor" in supported_modes:
+            score += 1
+        if "AP" in supported_modes:
+            score += 1
+
+        phy_to_vifs[phy_number].append((card, score))
+
+    # each phy number map to a sublist containing (card, score)
+    vif_score_tuples = [sublist[0] for sublist in phy_to_vifs.values()]
+    # sort with score
+    vif_score_tuples = sorted(vif_score_tuples, key=lambda tup: -tup[1])
+
+    perfect_card, is_single_perfect_phy = get_perfect_card(phy_to_vifs,
+                                                           vif_score_tuples)
+
+    return perfect_card, is_single_perfect_phy
 
 def get_network_manager_objects(system_bus):
     """

--- a/wifiphisher/extensions/deauth.py
+++ b/wifiphisher/extensions/deauth.py
@@ -226,6 +226,9 @@ class Deauth(object):
         :return: A list with all interested channels
         :rtype: list
         """
+        # we cannot do frequency hopping if users have only one card
+        if not self._data.is_freq_hop_allowed:
+            return [self._data.target_ap_channel]
 
         if self._data.target_ap_bssid and not self._data.args.deauth_essid:
             return [self._data.target_ap_channel]

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -526,14 +526,14 @@ class WifiphisherEngine:
                 self.op_mode = OP_MODE1
             else:
                 if card is not None:
-                    interfaces.add_virtual_interface(card)
+                    self.network_manager.add_virtual_interface(card)
                 self.op_mode = OP_MODE5
         if args.internetinterface and not args.nojamming:
             if not is_single_perfect_card:
                 self.op_mode = OP_MODE2
             else:
                 if card is not None:
-                    interfaces.add_virtual_interface(card)
+                    self.network_manager.add_virtual_interface(card)
                 self.op_mode = OP_MODE6
         if args.internetinterface and args.nojamming:
             self.op_mode = OP_MODE3


### PR DESCRIPTION
@sophron @blackHatMonkey 

This PR implements #652. 
I have tested with the adapter TL-WN722N and it can successfully deauth the victims.

I modify some flow in the `pywifiphisher` for the reason that
  * In the original flow we may have two cards up with the `managed` mode; however some
of the adaters do not allow two cards in `managed` mode with `ifconfig up` state, so I need to let them in `down` state since we use one card to do both jamming and lunching AP.

  * for the same reason, I remove the `pyw.down()` and `pyw.up()` in the `set_interface_mac` and `set_interface_mode`  and do slight modification for the test cases.

I also modify a little code in the extension manager. Since when we only use one card we cannot do frequency hopping.

