### PR TITLE
Initialize the CH number of mon_iface to the CH number of fakeAP

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -750,6 +750,8 @@ class WifiphisherEngine:
                 'args': args
             }
             self.em.set_interface(mon_iface)
+            self.network_manager.set_interface_channel(mon_iface,
+                                                       int(channel))
             extensions = DEFAULT_EXTENSIONS
             if args.lure10_exploit:
                 extensions.append(LURE10_EXTENSION)


### PR DESCRIPTION
I found that the channel of monitor interface stayed at the channel number of recon phase. 
We should init the channel to the channel number of target AP right?