### PR TITLE
Fix getting invalid channel number in malformed frame

### DIFF
--- a/wifiphisher/common/constants.py
+++ b/wifiphisher/common/constants.py
@@ -17,6 +17,7 @@ EXTENSIONS_LOADPATH = "wifiphisher.extensions."
 PORT = 8080
 SSL_PORT = 443
 CHANNEL = 6
+ALL_2G_CHANNELS = range(1, 14)
 WEBSITE = "https://wifiphisher.org"
 PUBLIC_DNS = "8.8.8.8"
 PEM = dir_of_data + 'cert/server.pem'

--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -400,7 +400,7 @@ class AccessPointFinder(object):
 
         # if the stop flag not set, change the channel
         while self._should_continue:
-            for channel in range(1, 14):
+            for channel in constants.ALL_2G_CHANNELS:
                 # added this check to reduce shutdown time
                 if self._should_continue:
                     self._network_manager.set_interface_channel(self._interface, channel)

--- a/wifiphisher/extensions/deauth.py
+++ b/wifiphisher/extensions/deauth.py
@@ -112,6 +112,9 @@ class Deauth(object):
                 try:
                     # channel is in the third IE of Dot11Elt
                     channel = ord(packet[dot11.Dot11Elt][2].info)
+                    # check if this is valid channel
+                    if channel not in constants.ALL_2G_CHANNELS:
+                        return (channels, self.packets_to_send)
                     channels.append(str(channel))
                 except (TypeError, IndexError):
                     # just return empty channel and packet
@@ -126,7 +129,7 @@ class Deauth(object):
 
             # create a list of addresses that are not acceptable
             non_valid_list = self._non_client_addresses +\
-            self._observed_clients
+                self._observed_clients
 
             # if sender or receirver is valid and not already a
             # discovered client check to see if either one is a client
@@ -181,5 +184,5 @@ class Deauth(object):
         :rtype: list
         """
         if self._is_frenzy:
-            return [str(k) for k in range(1, 14)]
+            return [str(k) for k in constants.ALL_2G_CHANNELS]
         return [self._data.target_ap_channel]


### PR DESCRIPTION
Fix two things:
 * Check for the channel is valid in the sniffed frame in fenzy mode deauth
 * pep8 fix for recon.py