### PR TITLE
fix(deauth): return wrong data type for send_channels

### DIFF
--- a/tests/test_deauth.py
+++ b/tests/test_deauth.py
@@ -691,7 +691,7 @@ class TestDeauth(unittest.TestCase):
 
         message = "Failed to send target AP's channel"
 
-        expected = self.target_channel
+        expected = [self.target_channel]
 
         self.assertEqual(expected, actual, message)
 

--- a/wifiphisher/extensions/deauth.py
+++ b/wifiphisher/extensions/deauth.py
@@ -204,5 +204,5 @@ class Deauth(object):
         """
 
         # return target's channel if available otherwise all channels
-        return (self._data.target_ap_channel if self._data.target_ap_bssid else
+        return ([self._data.target_ap_channel] if self._data.target_ap_bssid else
                 map(str, constants.ALL_2G_CHANNELS))


### PR DESCRIPTION
Just found the problem for the deauth module today T^T 
After this fixed, the deauth attack behaves correctly for the deauth attack without `--essid` option.