### PR TITLE
fix(em): channel number of deauth card is not correct

### DIFF
--- a/wifiphisher/common/extensions.py
+++ b/wifiphisher/common/extensions.py
@@ -134,6 +134,10 @@ class ExtensionManager(object):
         .. note: The channel range is between 1 to 13
         """
 
+        # set the current channel to the ap channel
+        self._nm.set_interface_channel(
+            self._interface, int(self._current_channel))
+
         # if the stop flag not set, change the channel
         while self._should_continue:
             for channel in self._channels_to_hop:


### PR DESCRIPTION
@sophron 

last time I create a PR for fixing the channel number of the deauth card, today I can reproduce it. After digging out, I found that the deauth channel will be stayed in the ap selection stage.

Though we'll call the channel_hop function, there still has a problem, currently we define `_current_channel="1"`, if the target ap is located in `channel 1`, then it will not do the frequecy hopping and just stay in the channel after the ap selection stage.