### PR TITLE
feat(Deauth): Add essid deauth attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Following are all the options along with their descriptions (also available with
 |-iDM| --mac-deauth-interface| Specify the MAC address of the jamming interface. Example: -iDM E8:2A:EA:00:00:00|
 |-iNM| --no-mac-randomization| Do not change any MAC address.|
 |-hC|--handshake-capture|Capture of the WPA/WPA2 handshakes for verifying passphrase. Example: -hC capture.pcap|
+|-dE|--deauth-essid|Deauth all the BSSIDs having same ESSID from AP selection or the ESSID given by -e option.|
 
 
 ## Screenshots

--- a/tests/test_deauth.py
+++ b/tests/test_deauth.py
@@ -802,7 +802,7 @@ class TestDeauth(unittest.TestCase):
         # check the packets
         self.assertEqual(result[1], [], message1)
 
-    def test_is_attacking_bssid_target_ap_bssid_true(self):
+    def test_is_target_target_ap_bssid_true(self):
         """
         Get the target attacking bssid for the speficic ESSID
         when --essid is not used
@@ -811,13 +811,13 @@ class TestDeauth(unittest.TestCase):
         packet = dot11.RadioTap() / dot11.Dot11() / dot11.Dot11Beacon() / essid
         packet.addr3 = "99:99:99:99:99:99"
         self.deauth_obj0._data.args.deauth_essid = True
-        result = self.deauth_obj0._is_attacking_bssid(packet)
+        result = self.deauth_obj0._is_target(packet)
 
         expected = True
         message = "Fail to check the attacking essid: " + self.target_essid
         self.assertEqual(result, expected, message)
 
-    def test_is_attacking_bssid_target_ap_bssid_None_true(self):
+    def test_is_target_target_ap_bssid_None_true(self):
         """
         Get the target attacking bssid for the speficic ESSID
         when --essid is not used
@@ -826,20 +826,20 @@ class TestDeauth(unittest.TestCase):
         packet = dot11.RadioTap() / dot11.Dot11() / dot11.Dot11Beacon() / essid
         packet.addr3 = "99:99:99:99:99:99"
         self.deauth_obj1._data.args.deauth_essid = True
-        result = self.deauth_obj0._is_attacking_bssid(packet)
+        result = self.deauth_obj1._is_target(packet)
 
         expected = True
         message = "Fail to check the attacking essid: " + self.target_essid
         self.assertEqual(result, expected, message)
 
-    def test_is_attacking_bssid_essid_non_decodable_error(self):
+    def test_is_target_essid_non_decodable_error(self):
         """
         Assign essid to a constant when it is utf-8 non-decodable
         """
         essid = dot11.Dot11Elt(ID='SSID', info='\x99\x87\x33')
         packet = dot11.RadioTap() / dot11.Dot11() / dot11.Dot11Beacon() / essid
         packet.addr3 = "99:99:99:99:99:99"
-        result = self.deauth_obj0._is_attacking_bssid(packet)
+        result = self.deauth_obj0._is_target(packet)
         expected = False
         message = 'Fail to raise the UnicodeDecodeError for non-printable essid'
         self.assertEqual(result, expected, message)

--- a/wifiphisher/extensions/deauth.py
+++ b/wifiphisher/extensions/deauth.py
@@ -82,7 +82,7 @@ class Deauth(object):
                 (to_ds and not from_ds and packet.addr1) or
                 None)
 
-    def _is_attacking_bssid(self, packet):
+    def _is_target(self, packet):
         """
         Check if this is the target attacking bssid
         :param self: A Deauth object
@@ -155,7 +155,7 @@ class Deauth(object):
         bssid = self._extract_bssid(packet)
         # check beacon if this is our target deauthing BSSID
         if (packet.haslayer(dot11.Dot11Beacon) and bssid not in self._deauth_bssids
-                and self._is_attacking_bssid(packet)):
+                and self._is_target(packet)):
             # listen beacon to get the target attacking BSSIDs for the
             # specified ESSID
             packets_to_send += self._craft_packet(bssid,

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -78,6 +78,13 @@ def parse_args():
               )
     )
     parser.add_argument(
+        "-dE",
+        "--deauth-essid",
+        help=("Deauth all the BSSIDs having same ESSID from AP selection or " +
+              "the ESSID given by -e option" 
+              ),
+        action='store_true')
+    parser.add_argument(
         "-p",
         "--phishingscenario",
         help=("Choose the phishing scenario to run." +


### PR DESCRIPTION
This PR is addressing for #146 

Also during the development I found our deauthing process for `--essid` is not so effective. The reason is there are too many beacons on the air and the receiver address for the beacon is `ff:ff:ff:ff:ff:ff` which we consider as an invalid address in our `get_packet` method. Thus I add a new variable called `deauth_bssids` to track add broadcast deauthentication.

Functional test is done for the following four cases:

   * wifiphisher (No frequency hopping only deauth on the same channel)
   * wifiphisher -dE (frequency hopping to find the attacking essid as selected in ap-selection)
   * wifiphisher --essid haha (frequency hopping to do frenzy deauth)
   * wifiphisher --essid haha -dE (frequency hopping to find the essid haha and do the deauthentication)

Test cases are added and the coverage is 100%.
