### PR TITLE
fix NetworkManager missing after shutdowning wifiphisher

### DIFF
--- a/wifiphisher/common/constants.py
+++ b/wifiphisher/common/constants.py
@@ -41,6 +41,10 @@ NON_CLIENT_ADDRESSES = set([WIFI_BROADCAST, WIFI_INVALID, WIFI_MULTICAST, WIFI_I
 DEFAULT_OUI = '00:00:00'
 LINES_OUTPUT = 3
 DN = open(os.devnull, 'w')
+INTERFERING_PROCS = ["wpa_action", "wpa_supplicant", "wpa_cli", "dhclient",
+                    "ifplugd", "dhcdbd", "dhcpcd", "udhcpc",
+                    "avahi-autoipd", "avahi-daemon", "wlassistant",
+                    "wifibox", "NetworkManager", "knetworkmanager"]
 
 # Modes of operation
 # Advanced


### PR DESCRIPTION
@sophron @blackHatMonkey 

The root cause why users met the problem of network_manager missing is because that we've toggled down the network manager; however users may not cleanly shut down wifiphisher and thus the network manager is missing on their system.

After thinking for a while, I decide to remove the toggling function since I feel it too dangerous for keeping this function in the start of beginning, and solve this problem by separating the logic by the `-iI` option.

 * if `-iI` option is given, that means we need to take care about whether the card is managed by the NetworkManager.
 * if `-iI` option is not given, that means we don't need to care about whether card is managed by NetworkManager as before (i.e. before we add the feature for wireless card accessing internet).

Functional test is done and including test cases to make coverage at 100%