### PR TITLE
fix unnecessary enabling monitor mode when essid option is used

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -667,7 +667,9 @@ class WifiphisherEngine:
             # make sure interfaces are not blocked
             self.network_manager.unblock_interface(ap_iface)
             self.network_manager.unblock_interface(mon_iface)
-            self.network_manager.set_interface_mode(mon_iface, "monitor")
+            # set monitor mode only when --essid is not given
+            if self.advanced_enabled() or args.essid is None:
+                self.network_manager.set_interface_mode(mon_iface, "monitor")
         except (interfaces.InvalidInterfaceError,
                 interfaces.InterfaceCantBeFoundError,
                 interfaces.InterfaceManagedByNetworkManagerError) as err:


### PR DESCRIPTION
@sophron @blackHatMonkey 
We only need to set the card to monitor mode when advanced mode is
used or essid option is not given. This should fix the issue mentioned
in #722.