### PR TITLE
Implement channel monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Following are all the options along with their descriptions (also available with
 |-hC|--handshake-capture|Capture of the WPA/WPA2 handshakes for verifying passphrase. Example: -hC capture.pcap|
 |-dE|--deauth-essid|Deauth all the BSSIDs having same ESSID from AP selection or the ESSID given by -e option.|
 ||--logging| Enable logging. Output will be saved to wifiphisher.log file.|
+|-cM|--channel-monitor|Monitor if the target access point changes the channel.|
 ||--payload-path| Enable the payload path. Intended for use with scenarios that serve payloads.|
 
 

--- a/tests/test_deauth.py
+++ b/tests/test_deauth.py
@@ -30,6 +30,7 @@ class TestDeauth(unittest.TestCase):
         self.target_essid = "Evil"
         self.args = mock.Mock()
         self.args.deauth_essid = False
+        self.args.channel_monitor = False
 
         data0 = custom_tuple(self.target_bssid, self.target_channel, self.rogue_mac,
                              self.args, self.target_essid, True)
@@ -40,8 +41,8 @@ class TestDeauth(unittest.TestCase):
         self.deauth_obj1 = deauth.Deauth(data1)
 
         # test for --deauth-essid
-        self.deauth_obj0._deauth_bssids = set()
-        self.deauth_obj1._deauth_bssids = set()
+        self.deauth_obj0._deauth_bssids = dict()
+        self.deauth_obj1._deauth_bssids = dict()
 
     def test_craft_packet_normal_expected(self):
         """
@@ -212,7 +213,7 @@ class TestDeauth(unittest.TestCase):
         self.packet.addr3 = bssid0
 
         # add target_bssid in the self._deauth_bssids
-        self.deauth_obj0._deauth_bssids.add(self.target_bssid)
+        self.deauth_obj0._deauth_bssids[self.target_bssid] = self.target_channel
 
         # run the method
         pkts_to_send0 = self.deauth_obj0.get_packet(self.packet)
@@ -301,7 +302,7 @@ class TestDeauth(unittest.TestCase):
         self.packet.addr3 = bssid
 
         # add the bssid to the deauth_bssid set
-        self.deauth_obj1._deauth_bssids.add(bssid)
+        self.deauth_obj1._deauth_bssids[bssid] = self.target_channel
 
         # run the method
         pkts_to_send = self.deauth_obj1.get_packet(self.packet)
@@ -650,7 +651,7 @@ class TestDeauth(unittest.TestCase):
         self.packet.addr3 = bssid
 
         # run the method
-        self.deauth_obj1._deauth_bssids.add(bssid)
+        self.deauth_obj1._deauth_bssids[bssid] = self.target_channel
         self.deauth_obj1.get_packet(self.packet)
         actual = self.deauth_obj1.send_output()
         expected = "DEAUTH/DISAS - {}".format(sender)
@@ -680,7 +681,7 @@ class TestDeauth(unittest.TestCase):
         self.packet.addr3 = bssid0
 
         # run the method
-        self.deauth_obj1._deauth_bssids.add(bssid0)
+        self.deauth_obj1._deauth_bssids[bssid0] = self.target_channel
         self.deauth_obj1.get_packet(self.packet)
 
         # change the packet details
@@ -689,7 +690,7 @@ class TestDeauth(unittest.TestCase):
         self.packet.addr3 = bssid1
 
         # run the method again
-        self.deauth_obj1._deauth_bssids.add(bssid1)
+        self.deauth_obj1._deauth_bssids[bssid1] = self.target_channel
         self.deauth_obj1.get_packet(self.packet)
 
         actual = self.deauth_obj1.send_output()

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -137,6 +137,10 @@ def parse_args():
     parser.add_argument(
         "--payload-path",
         help=("Payload path for scenarios serving a payload"))
+    parser.add_argument("-cM",
+                        "--channel-monitor",
+                        help="Monitor if target access point changes the channel.",
+                        action='store_true')
 
     return parser.parse_args()
 
@@ -160,6 +164,7 @@ def setup_logging(args):
             should_roll_over = os.path.isfile(LOG_FILEPATH)
         should_roll_over and root_logger.handlers[0].doRollover()
         logger.info("Starting Wifiphisher")
+
 
 def set_ip_fwd():
     """


### PR DESCRIPTION
@sophron @blackHatMonkey 

This PR addressed for #146 
Users can use `-cM` option to monitor if the target BSSID has changed the channel. If this happens I will clear the deauth frames in the old channels and add them to the new channel.

Beyond the scope of #146, we also need a framework to modify the shared variables for all the extension modules and the sending thread of extension manager. Currently I implement a way to send the command to the queue and handle this command on a particular thread to modify the shared variable so that there will no raising for the shared variables between different extensions.