### PR TITLE
fix route add fail for the ap interface

### DIFF
--- a/wifiphisher/common/accesspoint.py
+++ b/wifiphisher/common/accesspoint.py
@@ -139,15 +139,11 @@ class AccessPoint(object):
             stderr=constants.DN
         )
         # Give it some time to avoid "SIOCADDRT: Network is unreachable"
-        time.sleep(.5)
+        time.sleep(1)
         # Make sure that we have set the network properly.
         proc = subprocess.check_output(['ifconfig', str(self.interface)])
         if constants.NETWORK_GW_IP not in proc:
             return False
-        subprocess.call(('route add -net %s netmask %s gw %s' %
-                         (constants.NETWORK_IP, constants.NETWORK_MASK,
-                          constants.NETWORK_GW_IP)),
-                        shell=True)
 
     def start(self):
         """


### PR DESCRIPTION
When I do the test for the logging branch I found sometimes tool will print out the following log:

    [*] Starting the fake access point...
    SIOCADDRT: Network is down

And I need to give more time delay to prevent this happen.
Though this can fix this problem I don't know why here we need to use the `route add` command. 
The command looks like the following:
`route add -net 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1` means that we want to redirect all the frames to the destination `10.0.0.*` to the gateway `10.0.0.1`. I don't know what's the intention for doing this since we only have one sub-network `10.0.0.*` ? 
