### PR TITLE
Refactor extensions

### DIFF
--- a/wifiphisher/extensions/deauth.py
+++ b/wifiphisher/extensions/deauth.py
@@ -6,6 +6,7 @@ Extension that sends 3 DEAUTH/DISAS Frames:
 """
 
 import logging
+from collections import defaultdict
 import scapy.layers.dot11 as dot11
 import wifiphisher.common.constants as constants
 
@@ -35,6 +36,8 @@ class Deauth(object):
         self._data = data
         # the bssids having the same ESSID
         self._deauth_bssids = set()
+        # channel mapping to the frames list
+        self._packets_to_send = defaultdict(list)
 
     @staticmethod
     def _craft_packet(sender, receiver, bssid):
@@ -130,7 +133,6 @@ class Deauth(object):
         :rtype: tuple
         """
 
-        channels = list()
         packets_to_send = list()
 
         # basic malformed frame check
@@ -138,12 +140,12 @@ class Deauth(object):
             # Discard WDS frame
             ds_value = packet.FCfield & 3
             if ds_value == 3:
-                return ([], [])
+                return self._packets_to_send
             receiver = packet.addr1
             sender = packet.addr2
         except AttributeError:
             logger.debug("Malformed frame doesn't contain address fields")
-            return ([], [])
+            return self._packets_to_send
 
         # obtain the channel for this packet
         try:
@@ -152,13 +154,11 @@ class Deauth(object):
 
             # check if this is valid channel
             if channel not in constants.ALL_2G_CHANNELS:
-                return ([], [])
-
-            channels.append(str(channel))
+                return self._packets_to_send
         except (TypeError, IndexError):
             # just return empty channel and packet
             logger.debug("Malformed frame doesn't contain channel field")
-            return ([], [])
+            return self._packets_to_send
 
         bssid = self._extract_bssid(packet)
         # check beacon if this is our target deauthing BSSID
@@ -173,7 +173,7 @@ class Deauth(object):
             self._deauth_bssids.add(bssid)
 
         if bssid not in self._deauth_bssids:
-            return ([], [])
+            return self._packets_to_send
 
         clients = self._add_clients(sender, receiver, bssid)
         if clients:
@@ -181,7 +181,9 @@ class Deauth(object):
             packets_to_send += clients[1]
             logger.info("Client with BSSID {} is now getting deauthenticated".format(clients[0]))
 
-        return (channels, packets_to_send)
+        self._packets_to_send[str(channel)] += packets_to_send
+
+        return self._packets_to_send
 
     def _add_clients(self, sender, receiver, bssid):
         """

--- a/wifiphisher/extensions/handshakeverify.py
+++ b/wifiphisher/extensions/handshakeverify.py
@@ -9,6 +9,7 @@ import hmac
 import hashlib
 import logging
 from collections import deque
+from collections import defaultdict
 from pbkdf2 import PBKDF2
 import scapy.layers.dot11 as dot11
 import wifiphisher.common.constants as constants
@@ -92,6 +93,8 @@ class Handshakeverify(object):
         self._is_captured = False
         # check if the capture given by user is processed
         self._is_first = True
+        # channel map to frame list
+        self._packets_to_send = defaultdict(list)
 
     @staticmethod
     def _prf512(key, const_a, const_b):
@@ -304,7 +307,7 @@ class Handshakeverify(object):
             else:
                 break
 
-        return [["*"], []]
+        return self._packets_to_send
 
     def send_output(self):
         """

--- a/wifiphisher/extensions/lure10.py
+++ b/wifiphisher/extensions/lure10.py
@@ -7,6 +7,7 @@ Location Service
 """
 
 import logging
+from collections import defaultdict
 import wifiphisher.common.constants as constants
 import scapy.layers.dot11 as dot11
 
@@ -32,6 +33,8 @@ class Lure10(object):
 
         self.first_run = True
         self.data = shared_data
+        # store channel to frame list
+        self._packets_to_send = defaultdict(list)
 
     def get_packet(self, pkt):
         """
@@ -50,6 +53,10 @@ class Lure10(object):
 
         beacons = list()
         bssid = str()
+
+        # initiliate the _packets_to_send in first run
+        if self.first_run:
+            self._packets_to_send["*"] = beacons
 
         # only run this code once
         if self.first_run and self.data.args.lure10_exploit:
@@ -81,8 +88,8 @@ class Lure10(object):
 
                     # make sure this block is never executed again and the notification occurs
                     self.first_run = False
-
-        return (["*"], beacons)
+            self._packets_to_send["*"] = beacons
+        return self._packets_to_send
 
     def send_output(self):
         """


### PR DESCRIPTION
@sophron as our discussion in #726 this PR refactor the three extension modules.

Each extension modules will maintain one _packets_to_send and we update the _packets_to_send of the `extension_manager` on every run of the `_process_packet`.

Later on I will base on this PR to develop #726 which should be relatively straightforward.
