### PR TITLE
Macmatcher redesign part 1

### DIFF
--- a/tests/test_macmatcher.py
+++ b/tests/test_macmatcher.py
@@ -1,0 +1,21 @@
+import mock
+import StringIO
+import wifiphisher.common.macmatcher as macmatcher
+
+
+@mock.patch("__builtin__.open")
+def test_parse_oui_file(mock_open):
+    """
+    Test parse_oui_file function with a single entry file
+    """
+    oui_file = "FILE LOCATION"
+    identifier = "07db21"
+    vendor = "HELL"
+    logo = ""
+
+    mock_open.return_value = StringIO.StringIO("{}|{}".format(identifier, vendor))
+    actual = macmatcher.parse_oui_file(oui_file)
+    expected = {identifier: vendor}
+    message = "Failed to parse the oui file"
+
+    assert actual == expected, message

--- a/wifiphisher/common/macmatcher.py
+++ b/wifiphisher/common/macmatcher.py
@@ -130,3 +130,39 @@ class MACMatcher(object):
         """
 
         del self._mac_to_vendor
+
+
+########################################
+# everything after this line is for the next patch
+########################################
+
+
+def parse_oui_file(oui_file):
+    """
+    Return a dictionary containing the vendors information parsed
+    from the oui_file
+
+    :param oui_file: Location of the oui_file
+    :type oui_file: str
+    :return: dictionary containing parsed vendors
+    :rtype: dict
+    :Example:
+
+    # assuming somefile.txt contains:
+    # 45a23b|Fake Inc.
+    >>> oui_file = "somefile.txt"
+    >>> my_dict = parse_oui_file(oui_file)
+    >>> my_dict
+    {"45a23b": "Fake Inc."}
+    """
+
+    file_handler = open(oui_file, "r")
+
+    not_a_comment = lambda entry: not entry.startswith("#")
+    split = lambda string: string.rstrip().split("|")
+
+    vendor_information = dict(map(split, filter(not_a_comment, file_handler.readlines())))
+
+    file_handler.close()
+
+    return vendor_information


### PR DESCRIPTION
I think we are adding a huge burden with the current direction that we are going with the tool. Therefore I'm redesigning the `macmatcher` with an imperative style rather than OOP. It should make it easier to test and write pure functions compared to OOP. I have not modified any existing code and will add the replacement functions one at a time(for easier reviewing). When all the functions are done we can remove the old code. 