### PR TITLE
fix(pywifiphisher): UnboundLocalError in logs

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -523,7 +523,7 @@ class WifiphisherEngine:
         except (interfaces.InvalidInterfaceError,
                 interfaces.InterfaceCantBeFoundError,
                 interfaces.InterfaceManagedByNetworkManagerError) as err:
-            logger.exception("Setting {} to monitor mode".format(mon_iface))
+            logger.exception("The following error has occurred:")
             print ("[{0}!{1}] {2}").format(R, W, err)
 
             time.sleep(1)


### PR DESCRIPTION
Fix an UnboundLocalError that would happen when logging an exception
in case only a single adapter with monitor mode was supplied.

See also #764