### PR TITLE
Add command line argument checks

### DIFF
--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1339,3 +1339,33 @@ class TestIsWirelessInterface(unittest.TestCase):
         actual = interfaces.is_wireless_interface(interface_name)
         message = 'Fail to return true when the card is wireless card'
         self.assertTrue(actual, message)
+
+
+@mock.patch("wifiphisher.common.interfaces.pyric.pyw")
+def test_does_have_mode_has_mode(pyric):
+    """
+    Test does_have_mode function when the interface has the requested
+    mode
+    """
+    pyric.getcard.return_value = None
+    pyric.devmodes.return_value = ["AP", "monitor"]
+
+    name = "wlan0"
+    mode = "AP"
+
+    assert interfaces.does_have_mode(name, mode) == True
+
+
+@mock.patch("wifiphisher.common.interfaces.pyric.pyw")
+def test_does_have_mode_has_not_mode(pyric):
+    """
+    Test does_have_mode function when the interface doesn't have the
+    requested mode
+    """
+    pyric.getcard.return_value = None
+    pyric.devmodes.return_value = ["AP"]
+
+    name = "wlan0"
+    mode = "monitor"
+
+    assert interfaces.does_have_mode(name, mode) == False 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1352,8 +1352,9 @@ def test_does_have_mode_has_mode(pyric):
 
     name = "wlan0"
     mode = "AP"
+    message = "Failed to return True when interface had mode available"
 
-    assert interfaces.does_have_mode(name, mode) == True
+    assert interfaces.does_have_mode(name, mode) == True, message
 
 
 @mock.patch("wifiphisher.common.interfaces.pyric.pyw")
@@ -1367,5 +1368,6 @@ def test_does_have_mode_has_not_mode(pyric):
 
     name = "wlan0"
     mode = "monitor"
+    message = "Failed to return False when interface didn't have mode available"
 
-    assert interfaces.does_have_mode(name, mode) == False 
+    assert interfaces.does_have_mode(name, mode) == False, message

--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -930,3 +930,25 @@ def generate_random_address():
                                                                          random.randint(0, 255),
                                                                          random.randint(0, 255))
     return mac_address
+
+def does_have_mode(interface, mode):
+    """
+    Return whether the provided interface has the mode
+
+    :param interface: Name of the interface
+    :param mode: Mode of operation
+    :type interface: str
+    :type mode: str
+    :return: True if interface has the mode and False otherwise
+    :rtype: bool
+    :Example:
+
+        >>> does_have_mode("wlan0", "AP")
+        True
+
+        >>> does_have_mode("wlan1", "monitor")
+        False
+    """
+    card = pyric.pyw.getcard(interface)
+
+    return mode in pyric.pyw.devmodes(card)

--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -931,6 +931,7 @@ def generate_random_address():
                                                                          random.randint(0, 255))
     return mac_address
 
+
 def does_have_mode(interface, mode):
     """
     Return whether the provided interface has the mode

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -7,6 +7,8 @@ resources of the host system
 import sys
 import os
 import logging
+import argparse
+import pyric
 import wifiphisher.common.interfaces as interfaces
 import wifiphisher.common.constants as constants
 import wifiphisher.extensions.handshakeverify as handshakeverify
@@ -263,3 +265,18 @@ class OpMode(object):
 
         return self.op_mode in [constants.OP_MODE1,
                                 constants.OP_MODE2]
+
+
+def validate_ap_interface(interface):
+    """
+    Validate the given interface
+
+    :param interface: Name of an interface
+    :type interface: str
+    :return: None
+    :rtype: None
+    :raises: argparse.ArgumentTypeError in case of invalid interface
+    """
+    if not(pyric.pyw.isinterface(interface) and interfaces.does_have_mode(interface, "AP")):
+        raise argparse.ArgumentTypeError("Provided interface ({}) either doesn't exist or "
+                                         " supports AP mode".format(interface))

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -50,6 +50,7 @@ def parse_args():
     parser.add_argument(
         "-aI",
         "--apinterface",
+        type=opmode.validate_ap_interface,
         help=("Manually choose an interface that supports AP mode for  " +
               "spawning an AP. " +
               "Example: -aI wlan0"


### PR DESCRIPTION
Add the function to check if an interface supports a specific mode. This is part of a multiple PR that essentially allows us to check if the provided interface in the command line arguments is valid. So an example of this would be:
```
wifiphisher --ap-interface HAHA
usage: wifiphisher.py ...
error: argument --ap-interface: HAHA is not a valid interface
```
This allows us to use this interface right away in the program since we know its valid.

Also I placed this function in the `constants` since this function should also be used when finding interfaces.