### PR TITLE
exclude 5g channels in recon module

### DIFF
--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -238,11 +238,15 @@ class AccessPointFinder(object):
         :type packet: scapy.layers.RadioTap
         :return: None
         :rtype: None
+        :note: return when the frame is malformed or the channel is not
+        in the 2G channel list
         """
 
         elt_section = packet[dot11.Dot11Elt]
         try:
             channel = str(ord(packet[dot11.Dot11Elt:3].info))
+            if int(channel) not in constants.ALL_2G_CHANNELS:
+                return
         except (TypeError, IndexError):
             return
 


### PR DESCRIPTION
This PR exclude the 5G channel in the recon module and it will fix that users use the 5g channel to run the hostapd and result fail.