### PR TITLE
fix recon and simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "2.7"
 
 install:
+  - pip install pylint tox
   - python setup.py install
 
 # We need system's site_packages for python-dbus.
@@ -16,11 +17,8 @@ virtualenv:
     system_site_packages: true
 
 script:
-  - pip install -r requirements.txt
-  - pip install -r requirements-dev.txt
   - pylint --errors-only wifiphisher
   - tox -e ALL
-  - python setup.py install
 
 branches:
   only:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
-tox
-pylint
-pytest
-mock
-sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-roguehostapd
-scapy
-pyric
-pbkdf2

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
                "Intended Audience :: Information Technology"]
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
 INSTALL_REQUIRES = ["PyRIC", "tornado", "dbus-python",
-                    "pbkdf2", "roguehostapd"]
+                    "pbkdf2", "roguehostapd", "scapy"]
 CMDCLASS = {"clean": CleanCommand,}
 
 # run setup

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -83,7 +83,7 @@ class OpMode(object):
                 not (args.noextensions and args.apinterface):
             sys.exit('[' + constants.R + '-' + constants.W +
                      '] --apinterface (-aI) and --extensionsinterface (-eI)'
-                     '(or --noextensions (-nJ)) are used in conjuction.')
+                     '(or --noextensions (-nE)) are used in conjuction.')
 
         if args.noextensions and args.extensionsinterface:
             sys.exit('[' + constants.R + '-' + constants.W +
@@ -278,8 +278,8 @@ def validate_ap_interface(interface):
         pyric.pyw.isinterface(interface) and \
         interfaces.does_have_mode(interface, "AP")):
 
-        raise argparse.ArgumentTypeError("Provided interface ({}) \
-                                        either does not exist or "
+        raise argparse.ArgumentTypeError("Provided interface ({})"
+                                         " either does not exist or"
                                          " does not support AP mode" \
                                         .format(interface))
     return interface

--- a/wifiphisher/common/recon.py
+++ b/wifiphisher/common/recon.py
@@ -243,7 +243,7 @@ class AccessPointFinder(object):
 
         elt_section = packet[dot11.Dot11Elt]
         try:
-            channel = str(ord(packet[int(dot11.Dot11Elt):3].info))
+            channel = str(ord(packet[dot11.Dot11Elt][2].info))
             if int(channel) not in constants.ALL_2G_CHANNELS:
                 return
         except (TypeError, IndexError):


### PR DESCRIPTION
1. Fix some wordings and also after the merge of travis fix wifiphisher cannot find the access points in ap selection stage.
2. Also simplify the .travis file: I think the main root causes for building fail before are the following reasons.
     a. We don't have scapy dependency (add in setup.py now)
     b. dbus dependency (as @d33tah mentions in .travis.yml : add in site-package)
     c. tornando (as @d33tah mentions in .travis.yml)