### PR TITLE
fix hostapd lunch fail when roguehostapd is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Following are all the options along with their descriptions (also available with
 |-wP|--wps-pbc|Monitor if the button on a WPS-PBC Registrar side is pressed.|
 |-wAI|--wpspbc-assoc-interface|The WLAN interface used for associating to the WPS AccessPoint.|
 |-kb|--known-beacons|Perform the known beacons Wi-Fi automatic association technique.|
+|-fH|--force-hostapd|Force the usage of hostapd installed in the system.|
 
 
 ## Screenshots

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ This module tries to install all the required software.
 from __future__ import print_function
 import sys
 import os
-from ctypes.util import find_library
 from setuptools import setup, find_packages, Command
 import wifiphisher.common.constants as constants
 
@@ -58,44 +57,6 @@ def get_dnsmasq():
 
         sys.exit(dnsmasq_message)
 
-
-def get_hostapd():
-    """
-    Try to install hostapd on host system if not present
-
-    :return: None
-    :rtype: None
-    """
-
-    if not os.path.isfile("/usr/sbin/hostapd"):
-        install = raw_input(("[" + constants.T + "*" + constants.W + "] hostapd not found in " +
-                             "/usr/sbin/hostapd, install now? [y/n] "))
-
-        if install == "y":
-            if os.path.isfile("/usr/bin/pacman"):
-                os.system("pacman -S hostapd")
-            elif os.path.isfile("/usr/bin/yum"):
-                os.system("yum install hostapd")
-            else:
-                os.system("apt-get -y install hostapd")
-        else:
-            sys.exit(("[" + constants.R + "-" + constants.W + "] hostapd not found in " +
-                      "/usr/sbin/hostapd"))
-
-    if not os.path.isfile("/usr/sbin/hostapd"):
-        hostapd_message = ("\n[" + constants.R + "-" + constants.W + "] Unable to install the " +
-                           "\'hostapd\' package!\n[" + constants.T + "*" + constants.W + "] " +
-                           "This process requires a persistent internet connection!\nPlease " +
-                           "follow the link below to configure your sources.list\n" + constants.B +
-                           "http://docs.kali.org/general-use/kali-linux-sources-list-" +
-                           "repositories\n" + constants.W + "[" + constants.G + "+" + constants.W +
-                           "] Run apt-get update for changes to take effect.\n[" + constants.G +
-                           "+" + constants.W + "] Rerun the script to install hostapd.\n[" +
-                           constants.R + "!" + constants.W + "] Closing")
-
-        sys.exit(hostapd_message)
-
-
 # setup settings
 NAME = "wifiphisher"
 AUTHOR = "sophron"
@@ -126,8 +87,6 @@ setup(name=NAME, author=AUTHOR, author_email=AUTHOR_EMAIL, description=DESCRIPTI
       include_package_data=INCLUDE_PACKAGE_DATA, version=VERSION, entry_points=ENTRY_POINTS,
       install_requires=INSTALL_REQUIRES, classifiers=CLASSIFIERS, url=URL, cmdclass=CMDCLASS)
 
-# Get hostapd or dnsmasq if needed
-get_hostapd()
 get_dnsmasq()
 
 print()

--- a/wifiphisher/common/accesspoint.py
+++ b/wifiphisher/common/accesspoint.py
@@ -4,9 +4,9 @@ This module was made to fork the rogue access point
 import os
 import time
 import subprocess
-from roguehostapd import hostapd_controller
-from roguehostapd import hostapd_constants
 import wifiphisher.common.constants as constants
+import roguehostapd.config.hostapdconfig as hostapdconfig
+import roguehostapd.apctrl as apctrl
 
 
 class AccessPoint(object):
@@ -28,9 +28,21 @@ class AccessPoint(object):
         self.channel = None
         self.essid = None
         self.psk = None
+        self.force_hostapd = False
         # roguehostapd object
         self.hostapd_object = None
         self.deny_mac_addrs = []
+
+    def enable_system_hostapd(self):
+        """
+        Set the interface for the softAP
+        :param self: An AccessPoint object
+        :type self: AccessPoint
+        :return: None
+        :rtype: None
+        ..note: use hostapd on the system instead of using roguehostapd
+        """
+        self.force_hostapd = True
 
     def set_interface(self, interface):
         """
@@ -57,22 +69,6 @@ class AccessPoint(object):
         """
 
         self.deny_mac_addrs.extend(deny_mac_addrs)
-
-    def update_black_macs(self):
-        """
-        Update the black mac addresses for hostapd
-
-        :param self: A HostapdConfig object
-        :type self: HostapdConfig
-        :return: None
-        :rtype: None
-        """
-        with open(hostapd_constants.HOSTAPD_CONF_PATH, 'a') as output_fp:
-            output_fp.write('macaddr_acl=0\n')
-            output_fp.write('deny_mac_file='+constants.DENY_MACS_PATH+'\n')
-        with open(constants.DENY_MACS_PATH, 'w') as writer:
-            for mac_addr in self.deny_mac_addrs:
-                writer.write(mac_addr+'\n')
 
     def set_internet_interface(self, interface):
         """
@@ -190,41 +186,49 @@ class AccessPoint(object):
             "ssid": self.essid,
             "interface": self.interface,
             "channel": self.channel,
-            "karma_enable": 1
+            "deny_macs": self.deny_mac_addrs,
         }
         if self.psk:
-            hostapd_config['wpa_passphrase'] = self.psk
-
-        # create the option dictionary
-        hostapd_options = {
-            'debug_level': hostapd_constants.HOSTAPD_DEBUG_OFF,
-            'mute': True,
-            "eloop_term_disable": True
-        }
-
-        try:
-            self.hostapd_object = hostapd_controller.Hostapd()
-            self.hostapd_object.start(hostapd_config, hostapd_options)
-        except KeyboardInterrupt:
-            raise Exception
-        # when roguehostapd fail to start rollback to use the hostapd
-        # on the system
-        except BaseException:
-            hostapd_config.pop("karma_enable", None)
-            hostapd_options = {}
-            hostapd_config_obj = hostapd_controller.HostapdConfig()
-            hostapd_config_obj.write_configs(hostapd_config, hostapd_options)
-            self.update_black_macs()
-
-            # handle exception if hostapd is not installed in system
+            hostapd_config['wpa2password'] = self.psk
+        self.hostapd_object = apctrl.Hostapd()
+        if not self.force_hostapd:
+            try:
+                # Enable KARMA attack
+                hostapd_config["karma_enable"] = 1
+                # Enable WPSPBC KARMA attack
+                hostapd_config["wpspbc"] = True
+                hostapd_options = {
+                    'mute': True,
+                    'timestamp': False,
+                    "eloop_term_disable": True
+                }
+                self.hostapd_object.start(hostapd_config, hostapd_options)
+            except KeyboardInterrupt:
+                raise Exception
+            except BaseException:
+                print("[" + constants.R + "!" + constants.W + "] " +
+                      "Roguehostapd is not installed in the system! Please install"
+                      " roguehostapd manually (https://github.com/wifiphisher/roguehostapd)"
+                      " and rerun the script. Otherwise, you can run the tool with the"
+                      " --force-hostapd option to use hostapd but please note that using"
+                      " Wifiphisher with hostapd instead of roguehostapd will turn off many"
+                      " significant features of the tool.")
+                # just raise exception when hostapd is not installed
+                raise Exception
+        else:
+            # use the hostapd on the users' system
+            self.hostapd_object.create_hostapd_conf_file(hostapd_config,
+                                                         {})
             try:
                 self.hostapd_object = subprocess.Popen(
-                    ['hostapd', hostapd_constants.HOSTAPD_CONF_PATH],
+                    ['hostapd', hostapdconfig.ROGUEHOSTAPD_RUNTIME_CONFIGPATH],
                     stdout=constants.DN,
                     stderr=constants.DN)
             except OSError:
                 print("[" + constants.R + "!" + constants.W + "] " +
-                      "hostapd is not installed!")
+                      "hostapd is not installed in the system! Please download it"
+                      " using your favorite package manager"
+                      "(e.g. apt-get install hostapd) and rerun the script.")
                 # just raise exception when hostapd is not installed
                 raise Exception
 
@@ -248,10 +252,10 @@ class AccessPoint(object):
             self.hostapd_object.stop()
         except BaseException:
             subprocess.call('pkill hostapd', shell=True)
-            if os.path.isfile(hostapd_constants.HOSTAPD_CONF_PATH):
-                os.remove(hostapd_constants.HOSTAPD_CONF_PATH)
-            if os.path.isfile(constants.DENY_MACS_PATH):
-                os.remove(constants.DENY_MACS_PATH)
+            if os.path.isfile(hostapdconfig.ROGUEHOSTAPD_RUNTIME_CONFIGPATH):
+                os.remove(hostapdconfig.ROGUEHOSTAPD_RUNTIME_CONFIGPATH)
+            if os.path.isfile(hostapdconfig.ROGUEHOSTAPD_DENY_MACS_CONFIGPATH):
+                os.remove(hostapdconfig.ROGUEHOSTAPD_DENY_MACS_CONFIGPATH)
 
         if os.path.isfile('/var/lib/misc/dnsmasq.leases'):
             os.remove('/var/lib/misc/dnsmasq.leases')

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -144,6 +144,11 @@ def parse_args():
         "--known-beacons",
         help="Broadcast a number of beacon frames advertising popular WLANs",
         action='store_true')
+    parser.add_argument(
+        "-fH",
+        "--force-hostapd",
+        help="Force the usage of hostapd installed in the system",
+        action='store_true')
 
     return parser.parse_args()
 
@@ -526,6 +531,11 @@ class WifiphisherEngine:
         self.access_point.set_interface(ap_iface)
         self.access_point.set_channel(channel)
         self.access_point.set_essid(essid)
+        if args.force_hostapd:
+            print('[' + T + '*' + W + '] Using hostapd instead of roguehostapd.'
+                  " Many significant features will be turned off."
+                 )
+            self.access_point.enable_system_hostapd()
         if args.wpspbc_assoc_interface:
             wps_mac = self.network_manager.get_interface_mac(
                 args.wpspbc_assoc_interface)


### PR DESCRIPTION
When users fail to install `roguehostapd` we currently will degenerate to use the hostapd on the system; however since we create a `hostapd.conf` which has wps setting and this may cause the `hostapd on the system` fail to lunch (usually the system hostapd not compile with WPS config option).

Note: This PR can only be merged after we have a new release of roguehostapd.
