### PR TITLE
Fix 'No handlers could be found for logger "wifiphisher.pywifiphisher"' error

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -395,7 +395,7 @@ class WifiphisherEngine:
         except (interfaces.InvalidInterfaceError,
                 interfaces.InterfaceCantBeFoundError,
                 interfaces.InterfaceManagedByNetworkManagerError) as err:
-            logger.exception("The following error has occurred:")
+            logging.exception("The following error has occurred:")
             print("[{0}!{1}] {2}").format(R, W, err)
 
             time.sleep(1)


### PR DESCRIPTION
Fixed one line that was make it impossible to get the result of an exception in interface setup