### PR TITLE
Fixed the example of using argument "-eI" in description

### DIFF
--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -43,7 +43,7 @@ def parse_args():
         "-eI",
         "--extensionsinterface",
         help=("Manually choose an interface that supports monitor mode for " +
-              "deauthenticating the victims. " + "Example: -jI wlan1"))
+              "deauthenticating the victims. " + "Example: -eI wlan1"))
     parser.add_argument(
         "-aI",
         "--apinterface",


### PR DESCRIPTION
"Example: -jI wlan1" to "Example: -eI wlan1"