### PR TITLE
Add python3 branch to travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 branches:
   only:
   - master
+  - python3
 
 notifications:
   email:


### PR DESCRIPTION
Since python3 branch was added to move the code to python3 the `travis` must be run on there as well.
see also #937