### PR TITLE
chore:move dependency check from setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import sys
 import os
 from setuptools import setup, find_packages, Command
+from wifiphisher.common.dependencies import is_all_dependencies_installed
 import wifiphisher.common.constants as constants
 
 
@@ -43,7 +44,7 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
 # WORKAROUND: Download tornado 4.5.3 instead of latest so travis won't complain
 INSTALL_REQUIRES = ["PyRIC", "tornado==4.5.3",
-                    "pbkdf2", "roguehostapd", "scapy", "typing"]
+                    "pbkdf2", "roguehostapd", "scapy"]
 CMDCLASS = {"clean": CleanCommand,}
 
 # run setup
@@ -52,14 +53,11 @@ setup(name=NAME, author=AUTHOR, author_email=AUTHOR_EMAIL, description=DESCRIPTI
       include_package_data=INCLUDE_PACKAGE_DATA, version=VERSION, entry_points=ENTRY_POINTS,
       install_requires=INSTALL_REQUIRES, classifiers=CLASSIFIERS, url=URL, cmdclass=CMDCLASS)
 
-
-print()
-print("                     _  __ _       _     _     _               ")
-print("                    (_)/ _(_)     | |   (_)   | |              ")
-print("  ((.))    __      ___| |_ _ _ __ | |__  _ ___| |__   ___ _ __ ")
-print(r"    |      \ \ /\ / / |  _| | '_ \| '_ \| / __| '_ \ / _ \ '__|")
-print(r"   /_\      \ V  V /| | | | | |_) | | | | \__ \ | | |  __/ |   ")
-print(r"  /___\      \_/\_/ |_|_| |_| .__/|_| |_|_|___/_| |_|\___|_|   ")
-print(r" /     \                    | |                                ")
-print("                            |_|                                ")
-print("                                                               ")
+print("Checking required dependencies")
+DEPENDENCIES_RESULT = is_all_dependencies_installed()
+if DEPENDENCIES_RESULT.status:
+    print("All dependencies are installed.")
+else:
+    print("The follwoing dependencies are missing:")
+    for dependency in DEPENDENCIES_RESULT.missing:
+        print(dependency)

--- a/setup.py
+++ b/setup.py
@@ -20,42 +20,6 @@ class CleanCommand(Command):
     def run(self):
         os.system('rm -vrf ./build ./dist ./*.pyc ./*.tgz ./*.egg-info')
 
-def get_dnsmasq():
-    """
-    Try to install dnsmasq on host machine if not present
-
-    :return: None
-    :rtype: None
-    """
-
-    if not os.path.isfile("/usr/sbin/dnsmasq"):
-        install = raw_input(("[" + constants.T + "*" + constants.W + "] dnsmasq not found " +
-                             "in /usr/sbin/dnsmasq, " + "install now? [y/n] "))
-
-        if install == "y":
-            if os.path.isfile("/usr/bin/pacman"):
-                os.system("pacman -S dnsmasq")
-            elif os.path.isfile("/usr/bin/yum"):
-                os.system("yum install dnsmasq")
-            else:
-                os.system("apt-get -y install dnsmasq")
-        else:
-            sys.exit(("[" + constants.R + "-" + constants.W + "] dnsmasq " +
-                      "not found in /usr/sbin/dnsmasq"))
-
-    if not os.path.isfile("/usr/sbin/dnsmasq"):
-        dnsmasq_message = ("\n[" + constants.R + "-" + constants.W +
-                           "] Unable to install the \'dnsmasq\' package!\n" + "[" + constants.T +
-                           "*" + constants.W + "] This process requires a persistent internet " +
-                           "connection!\nPlease follow the link below to configure your " +
-                           "sources.list\n" + constants.B + "http://docs.kali.org/general-use/" +
-                           "kali-linux-sources-list-repositories\n" + constants.W + "[" +
-                           constants.G + "+" + constants.W + "] Run apt-get update for changes " +
-                           "to take effect.\n" + "[" + constants.G + "+" + constants.W + "] " +
-                           "Rerun the script to install dnsmasq.\n[" + constants.R + "!" +
-                           constants.W + "] Closing")
-
-        sys.exit(dnsmasq_message)
 
 # setup settings
 NAME = "wifiphisher"
@@ -79,7 +43,7 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
 # WORKAROUND: Download tornado 4.5.3 instead of latest so travis won't complain
 INSTALL_REQUIRES = ["PyRIC", "tornado==4.5.3",
-                    "pbkdf2", "roguehostapd", "scapy"]
+                    "pbkdf2", "roguehostapd", "scapy", "typing"]
 CMDCLASS = {"clean": CleanCommand,}
 
 # run setup
@@ -88,7 +52,6 @@ setup(name=NAME, author=AUTHOR, author_email=AUTHOR_EMAIL, description=DESCRIPTI
       include_package_data=INCLUDE_PACKAGE_DATA, version=VERSION, entry_points=ENTRY_POINTS,
       install_requires=INSTALL_REQUIRES, classifiers=CLASSIFIERS, url=URL, cmdclass=CMDCLASS)
 
-get_dnsmasq()
 
 print()
 print("                     _  __ _       _     _     _               ")

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ from __future__ import print_function
 import sys
 import os
 from setuptools import setup, find_packages, Command
-from wifiphisher.common.dependencies import is_all_dependencies_installed
-import wifiphisher.common.constants as constants
 
 
 class CleanCommand(Command):
@@ -53,11 +51,13 @@ setup(name=NAME, author=AUTHOR, author_email=AUTHOR_EMAIL, description=DESCRIPTI
       include_package_data=INCLUDE_PACKAGE_DATA, version=VERSION, entry_points=ENTRY_POINTS,
       install_requires=INSTALL_REQUIRES, classifiers=CLASSIFIERS, url=URL, cmdclass=CMDCLASS)
 
-print("Checking required dependencies")
-DEPENDENCIES_RESULT = is_all_dependencies_installed()
-if DEPENDENCIES_RESULT.status:
-    print("All dependencies are installed.")
-else:
-    print("The follwoing dependencies are missing:")
-    for dependency in DEPENDENCIES_RESULT.missing:
-        print(dependency)
+print()
+print("                     _  __ _       _     _     _               ")
+print("                    (_)/ _(_)     | |   (_)   | |              ")
+print("  ((.))    __      ___| |_ _ _ __ | |__  _ ___| |__   ___ _ __ ")
+print(r"    |      \ \ /\ / / |  _| | '_ \| '_ \| / __| '_ \ / _ \ '__|")
+print(r"   /_\      \ V  V /| | | | | |_) | | | | \__ \ | | |  __/ |   ")
+print(r"  /___\      \_/\_/ |_|_| |_| .__/|_| |_|_|___/_| |_|\___|_|   ")
+print(r" /     \                    | |                                ")
+print("                            |_|                                ")
+print("                                                               ")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,35 @@
+import mock
+from subprocess import CalledProcessError
+from wifiphisher.common.dependencies import (is_installed, Result, check_dependencies)
+
+
+@mock.patch(
+    "wifiphisher.common.dependencies.check_call", spec=True, return_value=True)
+def test_is_installed_installed_true(_):
+    """Test function when an application is installed."""
+    assert is_installed("myApplication")
+
+
+@mock.patch(
+    "wifiphisher.common.dependencies.check_call",
+    spec=True,
+    side_effect=CalledProcessError(1, "cmd", None))
+def test_is_installed_installed_false(_):
+    """Test function when an application is not installed."""
+    assert not is_installed("noApplication")
+
+
+@mock.patch(
+    "wifiphisher.common.dependencies.check_call", spec=True, return_value=True)
+def test_check_dependencies_all_installed_true(_):
+    """Test function when all dependecies are installed."""
+    assert check_dependencies() == Result(status=True, name="")
+
+
+@mock.patch(
+    "wifiphisher.common.dependencies.check_call",
+    spec=True,
+    side_effect=CalledProcessError(1, "cmd", None))
+def test_check_dependencies_all_not_installed_false(_):
+    """Test function when all not dependecies are installed."""
+    assert check_dependencies() == Result(status=False, name="dnsmasq")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,7 +1,7 @@
 import mock
 from subprocess import CalledProcessError
-from wifiphisher.common.dependencies import (is_installed, Result,
-                                             is_all_dependencies_installed)
+from wifiphisher.common.dependencies import (is_installed,
+                                             find_missing_dependencies)
 
 
 @mock.patch(
@@ -21,19 +21,16 @@ def test_is_installed_installed_false(_):
 
 
 @mock.patch(
-    "wifiphisher.common.dependencies.check_call",
-    spec=True,
-    return_value=True)
-def test_is_all_dependencies_installed_all_installed(_):
+    "wifiphisher.common.dependencies.check_call", spec=True, return_value=True)
+def test_find_missing_dependencies_all_installed(_):
     """Test function when all dependecies are installed."""
-    assert is_all_dependencies_installed() == Result(status=True, missing=[])
+    assert find_missing_dependencies() == []
 
 
 @mock.patch(
     "wifiphisher.common.dependencies.check_call",
     spec=True,
     side_effect=CalledProcessError(1, "cmd", None))
-def test_is_all_dependencies_installed_all_not_installed(_):
+def test_find_missing_dependencies_all_not_installed(_):
     """Test function when all not dependecies are installed."""
-    assert is_all_dependencies_installed() == Result(
-        status=False, missing=["dnsmasq", "roguehostapd"])
+    assert find_missing_dependencies()[:2] == ["dnsmasq", "iptables"]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,10 +1,27 @@
 import mock
-from wifiphisher.common.dependencies import (Result,
+from subprocess import CalledProcessError
+from wifiphisher.common.dependencies import (is_installed, Result,
                                              is_all_dependencies_installed)
 
 
 @mock.patch(
-    "wifiphisher.common.dependencies.find_executable",
+    "wifiphisher.common.dependencies.check_call", spec=True, return_value=True)
+def test_is_installed_installed_true(_):
+    """Test function when an application is installed."""
+    assert is_installed("myApplication")
+
+
+@mock.patch(
+    "wifiphisher.common.dependencies.check_call",
+    spec=True,
+    side_effect=CalledProcessError(1, "cmd", None))
+def test_is_installed_installed_false(_):
+    """Test function when an application is not installed."""
+    assert not is_installed("noApplication")
+
+
+@mock.patch(
+    "wifiphisher.common.dependencies.check_call",
     spec=True,
     return_value=True)
 def test_is_all_dependencies_installed_all_installed(_):
@@ -13,9 +30,9 @@ def test_is_all_dependencies_installed_all_installed(_):
 
 
 @mock.patch(
-    "wifiphisher.common.dependencies.find_executable",
+    "wifiphisher.common.dependencies.check_call",
     spec=True,
-    return_value=None)
+    side_effect=CalledProcessError(1, "cmd", None))
 def test_is_all_dependencies_installed_all_not_installed(_):
     """Test function when all not dependecies are installed."""
     assert is_all_dependencies_installed() == Result(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,35 +1,22 @@
 import mock
-from subprocess import CalledProcessError
-from wifiphisher.common.dependencies import (is_installed, Result, check_dependencies)
+from wifiphisher.common.dependencies import (Result,
+                                             is_all_dependencies_installed)
 
 
 @mock.patch(
-    "wifiphisher.common.dependencies.check_call", spec=True, return_value=True)
-def test_is_installed_installed_true(_):
-    """Test function when an application is installed."""
-    assert is_installed("myApplication")
-
-
-@mock.patch(
-    "wifiphisher.common.dependencies.check_call",
+    "wifiphisher.common.dependencies.find_executable",
     spec=True,
-    side_effect=CalledProcessError(1, "cmd", None))
-def test_is_installed_installed_false(_):
-    """Test function when an application is not installed."""
-    assert not is_installed("noApplication")
-
-
-@mock.patch(
-    "wifiphisher.common.dependencies.check_call", spec=True, return_value=True)
-def test_check_dependencies_all_installed_true(_):
+    return_value=True)
+def test_is_all_dependencies_installed_all_installed(_):
     """Test function when all dependecies are installed."""
-    assert check_dependencies() == Result(status=True, name="")
+    assert is_all_dependencies_installed() == Result(status=True, missing=[])
 
 
 @mock.patch(
-    "wifiphisher.common.dependencies.check_call",
+    "wifiphisher.common.dependencies.find_executable",
     spec=True,
-    side_effect=CalledProcessError(1, "cmd", None))
-def test_check_dependencies_all_not_installed_false(_):
+    return_value=None)
+def test_is_all_dependencies_installed_all_not_installed(_):
     """Test function when all not dependecies are installed."""
-    assert check_dependencies() == Result(status=False, name="dnsmasq")
+    assert is_all_dependencies_installed() == Result(
+        status=False, missing=["dnsmasq", "roguehostapd"])

--- a/wifiphisher/common/dependencies.py
+++ b/wifiphisher/common/dependencies.py
@@ -1,0 +1,41 @@
+"""Handle dependency check.
+
+This module checks for all the required dependency needed for full
+function.
+"""
+
+from typing import NamedTuple
+from subprocess import (check_call, CalledProcessError)
+from .constants import DN
+
+Result = NamedTuple("Result", [("status", bool), ("name", str)])
+
+
+def is_installed(application):
+    # type: (str) -> bool
+    """Check if application is installed.
+
+    Return True if application is installed and False otherwise.
+    """
+    try:
+        check_call(["which", application], stdout=DN, stderr=DN)
+    except CalledProcessError:
+        return False
+
+    return True
+
+
+def check_dependencies():
+    # type: () -> Result
+    """Check all required dependencies are installed.
+
+    Check to see if all the required depedencies are installed. It will
+    return as soon as it finds a missing dependency.
+    """
+    dependencies = ["dnsmasq"]
+
+    for dependency in dependencies:
+        if not is_installed(dependency):
+            return Result(status=False, name=dependency)
+
+    return Result(status=True, name="")

--- a/wifiphisher/common/dependencies.py
+++ b/wifiphisher/common/dependencies.py
@@ -3,13 +3,13 @@
 This module checks for all the required dependency needed for full
 function.
 """
-
-from collections import namedtuple
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from itertools import ifilterfalse
 from subprocess import (check_call, CalledProcessError)
 from wifiphisher.common.constants import DN
-
-
-Result = namedtuple("Result", ["status", "missing"])
 
 
 def is_installed(application):
@@ -26,18 +26,13 @@ def is_installed(application):
     return True
 
 
-def is_all_dependencies_installed():
-    # type: () -> Result
+def find_missing_dependencies():
+    # type: () -> List[str]
     """Check all required dependencies are installed.
 
     Check to see if all the required depedencies are installed. It will
-    return as soon as it finds a missing dependency.
+    return a list of all missing dependencies.
     """
-    dependencies = ["dnsmasq", "roguehostapd"]
-    missing = []  # type: List[str]
+    dependencies = ["dnsmasq", "iptables"]
 
-    for dependency in dependencies:
-        if not is_installed(dependency):
-            missing.append(dependency)
-
-    return Result(status=not missing, missing=missing)
+    return list(ifilterfalse(is_installed, dependencies))

--- a/wifiphisher/common/dependencies.py
+++ b/wifiphisher/common/dependencies.py
@@ -4,38 +4,25 @@ This module checks for all the required dependency needed for full
 function.
 """
 
-from typing import NamedTuple
-from subprocess import (check_call, CalledProcessError)
-from .constants import DN
-
-Result = NamedTuple("Result", [("status", bool), ("name", str)])
+from collections import namedtuple
+from distutils.spawn import find_executable
 
 
-def is_installed(application):
-    # type: (str) -> bool
-    """Check if application is installed.
-
-    Return True if application is installed and False otherwise.
-    """
-    try:
-        check_call(["which", application], stdout=DN, stderr=DN)
-    except CalledProcessError:
-        return False
-
-    return True
+Result = namedtuple("Result", ["status", "missing"])
 
 
-def check_dependencies():
+def is_all_dependencies_installed():
     # type: () -> Result
     """Check all required dependencies are installed.
 
     Check to see if all the required depedencies are installed. It will
     return as soon as it finds a missing dependency.
     """
-    dependencies = ["dnsmasq"]
+    dependencies = ["dnsmasq", "roguehostapd"]
+    missing = []  # type: List[str]
 
     for dependency in dependencies:
-        if not is_installed(dependency):
-            return Result(status=False, name=dependency)
+        if not find_executable(dependency):
+            missing.append(dependency)
 
-    return Result(status=True, name="")
+    return Result(status=not missing, missing=missing)

--- a/wifiphisher/common/dependencies.py
+++ b/wifiphisher/common/dependencies.py
@@ -5,10 +5,25 @@ function.
 """
 
 from collections import namedtuple
-from distutils.spawn import find_executable
+from subprocess import (check_call, CalledProcessError)
+from wifiphisher.common.constants import DN
 
 
 Result = namedtuple("Result", ["status", "missing"])
+
+
+def is_installed(application):
+    # type: (str) -> bool
+    """Check if application is installed.
+
+    Return True if application is installed and False otherwise.
+    """
+    try:
+        check_call(["which", application], stdout=DN, stderr=DN)
+    except CalledProcessError:
+        return False
+
+    return True
 
 
 def is_all_dependencies_installed():
@@ -22,7 +37,7 @@ def is_all_dependencies_installed():
     missing = []  # type: List[str]
 
     for dependency in dependencies:
-        if not find_executable(dependency):
+        if not is_installed(dependency):
             missing.append(dependency)
 
     return Result(status=not missing, missing=missing)

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -27,7 +27,7 @@ import wifiphisher.common.firewall as firewall
 import wifiphisher.common.accesspoint as accesspoint
 import wifiphisher.common.tui as tui
 import wifiphisher.common.opmode as opmode
-from wifiphisher.common.dependencies import is_all_dependencies_installed
+from wifiphisher.common.dependencies import find_missing_dependencies
 
 logger = logging.getLogger(__name__)
 
@@ -298,16 +298,18 @@ class WifiphisherEngine:
             print("[{0}!{1}] {2}").format(R, W, err)
 
     def start(self):
-        dependency_result = is_all_dependencies_installed()
-        if not dependency_result.status:
-            logger.error("The following dependencies are missing:")
-            print("The following dependencies are missing:")
-            for dependency in dependency_result.missing:
+        missing_dependencies = find_missing_dependencies()
+        if missing_dependencies:
+            message = "The following dependencies are missing:"
+            logger.error(message)
+            print(message)
+            for dependency in missing_dependencies:
                 logger.error(dependency)
-                print("dependency")
+                print(dependency)
 
-            logger.error("Please install and try again.")
-            print("Please install and try again.")
+            message = "Please install and try again."
+            logger.error(message)
+            print(message)
             sys.exit()
 
         # First of - are you root?

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -27,7 +27,7 @@ import wifiphisher.common.firewall as firewall
 import wifiphisher.common.accesspoint as accesspoint
 import wifiphisher.common.tui as tui
 import wifiphisher.common.opmode as opmode
-from .common.dependencies import check_dependencies
+from wifiphisher.common.dependencies import is_all_dependencies_installed
 
 logger = logging.getLogger(__name__)
 
@@ -298,10 +298,17 @@ class WifiphisherEngine:
             print("[{0}!{1}] {2}").format(R, W, err)
 
     def start(self):
-        dependency_result = check_dependencies()
+        dependency_result = is_all_dependencies_installed()
         if not dependency_result.status:
-            logger.error("{} is needed but not installed."
-                         "Please install and run again".format(dependency_result.name))
+            logger.error("The following dependencies are missing:")
+            print("The following dependencies are missing:")
+            for dependency in dependency_result.missing:
+                logger.error(dependency)
+                print("dependency")
+
+            logger.error("Please install and try again.")
+            print("Please install and try again.")
+            sys.exit()
 
         # First of - are you root?
         if os.geteuid():

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -27,6 +27,7 @@ import wifiphisher.common.firewall as firewall
 import wifiphisher.common.accesspoint as accesspoint
 import wifiphisher.common.tui as tui
 import wifiphisher.common.opmode as opmode
+from .common.dependencies import check_dependencies
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def parse_args():
     parser.add_argument(
         "-i",
         "--interface",
-        help=("Manually choose an interface that supports both AP and monitor " + 
+        help=("Manually choose an interface that supports both AP and monitor " +
               "modes for spawning the rogue AP as well as mounting additional " +
               "Wi-Fi attacks from Extensions (i.e. deauth). " +
               "Example: -i wlan1"))
@@ -297,6 +298,10 @@ class WifiphisherEngine:
             print("[{0}!{1}] {2}").format(R, W, err)
 
     def start(self):
+        dependency_result = check_dependencies()
+        if not dependency_result.status:
+            logger.error("{} is needed but not installed."
+                         "Please install and run again".format(dependency_result.name))
 
         # First of - are you root?
         if os.geteuid():


### PR DESCRIPTION
Move the dependency checks from the setup.py file to it's own module so building the project becomes easier. This is due to the fact of waiting on stdin in case exteranl dependency was not installed. The checks now happen at run time.

seealso #933