### PR TITLE
docs: fix argument typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Following are all the options along with their descriptions (also available with
 ||--payload-path| Enable the payload path. Intended for use with scenarios that serve payloads.|
 |-wP|--wps-pbc|Monitor if the button on a WPS-PBC Registrar side is pressed.|
 |-wAI|--wpspbc-assoc-interface|The WLAN interface used for associating to the WPS AccessPoint.|
-|-kb|--known-beacons|Perform the known beacons Wi-Fi automatic association technique.|
+|-kB|--known-beacons|Perform the known beacons Wi-Fi automatic association technique.|
 |-fH|--force-hostapd|Force the usage of hostapd installed in the system.|
 ||--dnsmasq-conf DNSMASQ_CONF|Determine the full path of dnmasq.conf file.|
 |-dK|--disable-karma|Disables KARMA attack.|


### PR DESCRIPTION
Fix a typo in the arguments section of the Readme.