### PR TITLE
Travis CI: Add parallel build on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@
 
 language: python
 
-dist: trusty
-
 python:
   - "2.7"
+  - "3.7"
+
+matrix:
+  allow_failures:
+    - python: "3.7"
 
 install:
   - pip install pylint tox scapy


### PR DESCRIPTION
https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail

Also, drop __trusty__ because it is EOL.
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment