### PR TITLE
setup.py: Define raw_input() in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ import os
 from setuptools import setup, find_packages, Command
 import wifiphisher.common.constants as constants
 
+try:
+    raw_input  # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 class CleanCommand(Command):
     """Custom clean command to tidy up the project root."""


### PR DESCRIPTION
raw_input() was removed in Python 3 in favor of a reworked version of input().