### PR TITLE
Travis CI has completely deprecated the sudo: tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# There's no sudo: required because it slows down Travis CI job startup
-# and we don't really need it with addons: apt.
-
 language: python
 
 python:


### PR DESCRIPTION
This PR only removes an out-of-date comment.

On the Tornado notes, what versions of Python does wifiphisher support?
Python 2.7 <= 2.7.9 have well known security flaws so wifiphisher should not encourage their use.
Python 3 < 3.5 are end of life so wifiphisher is not obliged to support them.
https://devguide.python.org/#branchstatus
https://devguide.python.org/devcycle/#end-of-life-branches