### PR TITLE
Added hotfix for 3.8 due to changed Thread Creation Policy

### DIFF
--- a/wifiphisher/common/phishinghttp.py
+++ b/wifiphisher/common/phishinghttp.py
@@ -4,14 +4,18 @@ import logging
 import os.path
 import re
 import time
+import asyncio
 
 import tornado.ioloop
 import tornado.web
+import tornado.platform.asyncio
 import wifiphisher.common.constants as constants
 import wifiphisher.common.extensions as extensions
 import wifiphisher.common.uimethods as uimethods
 import wifiphisher.common.victim as victim
 from tornado.escape import json_decode
+
+asyncio.set_event_loop_policy(tornado.platform.asyncio.AnyThreadEventLoopPolicy())
 
 hn = logging.NullHandler()
 hn.setLevel(logging.DEBUG)


### PR DESCRIPTION
Hello,

while trying to run Arch Linux i noticed that the http server was never started. Instead, there was an error that the event loop was empty. I traced it back to a change in the thread creating policy. With the code below, it worked again but I guess this should only be regarded a hotfix as the correct way to do this would be to create the thread in the correct place to begin with.
Cheers