### PR TITLE
Fixes #1232: Causing config.ini become empty file

### DIFF
--- a/wifiphisher/common/phishingpage.py
+++ b/wifiphisher/common/phishingpage.py
@@ -124,7 +124,7 @@ class PhishingTemplate(object):
             original_config.get('context', 'update_path'))
         filepath = os.path.join(dirname, payload_filename)
         config.set('context', 'update_path', filepath)
-        with open(config_path, 'wb') as configfile:
+        with open(config_path, 'w') as configfile:
             config.write(configfile)
 
     def update_payload_path(self, filename):


### PR DESCRIPTION
When a user provides a plugin input file path for a plugin update attack, the config.ini of the plugin update attack becomes empty due to invalid file mode used to write the new config.ini after selecting the plugin input file path i.e. `wb`. When the user tries to run the script in the next run, the config parser causes issue #1232 since the config.ini is empty. changing the config.ini write mode from `wb` to `w` fixes this issue.