### PR TITLE
Fix dependences problem [with tornado]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,6 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
                "Intended Audience :: System Administrators",
                "Intended Audience :: Information Technology"]
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
-# WORKAROUND: Download tornado 4.5.3 instead of latest so travis won't complain
 INSTALL_REQUIRES = ["pbkdf2", "scapy", "tornado>=5.0.0", "roguehostapd", "pyric"]
 DEPENDENCY_LINKS = \
 ["http://github.com/wifiphisher/roguehostapd/tarball/master#egg=roguehostapd-1.9.0", \

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ CLASSIFIERS = ["Development Status :: 5 - Production/Stable",
                "Intended Audience :: Information Technology"]
 ENTRY_POINTS = {"console_scripts": ["wifiphisher = wifiphisher.pywifiphisher:run"]}
 # WORKAROUND: Download tornado 4.5.3 instead of latest so travis won't complain
-INSTALL_REQUIRES = ["pbkdf2", "scapy", "tornado==4.5.3", "roguehostapd", "pyric"]
+INSTALL_REQUIRES = ["pbkdf2", "scapy", "tornado>=5.0.0", "roguehostapd", "pyric"]
 DEPENDENCY_LINKS = \
 ["http://github.com/wifiphisher/roguehostapd/tarball/master#egg=roguehostapd-1.9.0", \
 "http://github.com/sophron/pyric/tarball/master#egg=pyric-0.5.0"]


### PR DESCRIPTION
See Line 18, in "/common/phishinghttp.py". It uses a function/class called "AnyThreadEventLoopPolicy".

And See "https://github.com/tornadoweb/tornado/blob/master/tornado/platform/asyncio.py" L333. It said "versionadded:: 5.0".

But The package required by wifiphisher is "tornado==4.5.3". It must be up to 5.0.0 or It will throw this "AttributeError: module 'tornado.platform.asyncio has no attribute 'AnyThreadEventLoopPolicy'/".

My friend told me this issue. Have a good one. ;-)