### PR TITLE
Bypass nl80211 errors for internet interfaces

### DIFF
--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -402,7 +402,7 @@ class NetworkManager(object):
             proc = Popen(['nmcli', 'dev', 'set', interface, 'manage', 'no'], stderr=PIPE)
             err = proc.communicate()[1]
         except:
-            logger.error("Failed to make NetworkManager unmanage interface {0}: {1}".format(interface_name, err))
+            logger.error("Failed to make NetworkManager unmanage interface {0}: {1}".format(interface, err))
             raise InterfaceManagedByNetworkManagerError(interface)
         # Ensure that the interface is unmanaged
         if is_managed_by_network_manager(interface):
@@ -643,6 +643,7 @@ class NetworkManager(object):
         card = self._name_to_object[interface_name].card
 
         # unblock card if it is blocked
+
         if pyw.isblocked(card):
             pyw.unblock(card)
 
@@ -706,12 +707,14 @@ class NetworkManager(object):
         for card in self._vifs_add:
             pyw.devdel(card)
 
-    def start(self):
+    def start(self, args):
         """
         Start the network manager
 
         :param self: A NetworkManager object
         :type self: NetworkManager
+        :param args: An argparse.Namespace object
+        :type args: argparse.Namespace
         :return: None
         :rtype: None
         """
@@ -728,6 +731,8 @@ class NetworkManager(object):
             except pyric.error as error:
                 if error.args[0] in (93, 19):
                     pass
+                elif interface == args.internetinterface:
+                    return False
                 else:
                     raise error
 
@@ -752,7 +757,7 @@ class NetworkManager(object):
         self.remove_vifs_added()
 
 
-def is_add_vif_required(args):
+def is_add_vif_required(main_interface, internet_interface, wpspbc_assoc_interface):
     """
     Return the card if only that card support both monitor and ap
     :param args: Arguemnt from pywifiphisher
@@ -796,27 +801,17 @@ def is_add_vif_required(args):
     # map the phy interface to virtual interfaces
     # i.e. phy0 to wlan0
     phy_to_vifs = defaultdict(list)
-    # store the phy number for the internet access
-    invalid_phy_number = list()
-    # record the invalid_phy_number when it is wireless card
-    if args.internetinterface and pyw.iswireless(args.internetinterface):
-        card = pyw.getcard(args.internetinterface)
-        invalid_phy_number.append(card.phy)
-
-    if args.wpspbc_assoc_interface:
-        card = pyw.getcard(args.wpspbc_assoc_interface)
-        invalid_phy_number.append(card.phy)
 
     # map the phy# to the virtual interface tuples
     for vif in [vif for vif in pyw.interfaces() if pyw.iswireless(vif)]:
         # excluding the card that used for internet accessing
         # setup basic card information
         score = 0
-        card = pyw.getcard(vif)
-        phy_number = card.phy
-        if phy_number in invalid_phy_number:
+        if vif == internet_interface or vif == wpspbc_assoc_interface:
             continue
-
+        else:
+            card = pyw.getcard(vif)
+            phy_number = card.phy
         supported_modes = pyw.devmodes(card)
 
         if "monitor" in supported_modes:
@@ -825,21 +820,20 @@ def is_add_vif_required(args):
             score += 1
 
         phy_to_vifs[phy_number].append((card, score))
-
     # each phy number map to a sublist containing (card, score)
     vif_score_tuples = [sublist[0] for sublist in list(phy_to_vifs.values())]
     # sort with score
     vif_score_tuples = sorted(vif_score_tuples, key=lambda tup: -tup[1])
-
     use_one_phy = False
-    if args.interface:
-        card = pyw.getcard(args.interface)
+    # check the user-provided args.interface
+    if main_interface:
+        card = pyw.getcard(main_interface)
         phy_number = card.phy
         if phy_to_vifs[card.phy][0][1] == 2:
             perfect_card = card
             use_one_phy = True
         else:
-            raise InvalidInterfaceError(args.interface)
+            raise InvalidInterfaceError(main_interface)
     else:
         perfect_card, use_one_phy = get_perfect_card(
             phy_to_vifs, vif_score_tuples)

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -51,7 +51,8 @@ class OpMode(object):
         """
 
         self._perfect_card, self._use_one_phy =\
-            interfaces.is_add_vif_required(args)
+            interfaces.is_add_vif_required(args.interface, 
+                    args.internetinterface, args.wpspbc_assoc_interface)
         self._check_args(args)
 
     def _check_args(self, args):

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -408,7 +408,7 @@ class WifiphisherEngine:
         # Set operation mode
         self.opmode.set_opmode(args, self.network_manager)
 
-        self.network_manager.start()
+        self.network_manager.start(args)
 
         # TODO: We should have more checks here:
         # Is anything binded to our HTTP(S) ports?
@@ -423,8 +423,17 @@ class WifiphisherEngine:
                         args.internetinterface, "internet"):
                     internet_interface = args.internetinterface
                     if interfaces.is_wireless_interface(internet_interface):
-                        self.network_manager.unblock_interface(
+                        try:
+                          self.network_manager.unblock_interface(
                             internet_interface)
+                        except KeyError:
+                            # TODO: Find a workaround for managing blocked adapters that do not support nl80211
+                            # Calling unblock on internet interfaces might return a `Key Error` if it does not 
+                            # support nl80211. This will be a problem if the interface is blocked as it cannot
+                            # be unblocked automatically. Let the user know with a warning.
+                            logger.warning("Interface {} does not support 'nl80211'. In case it is blocked,\
+                                    you must unblock it manually".format(internet_interface))
+                            pass
                 logger.info("Selecting %s interface for accessing internet",
                             args.internetinterface)
             # check if the interface for WPS is valid


### PR DESCRIPTION
It should not be mandatory for an adapter that is only used as the 'internet interface' to be supporting `nl80211`. This PR introduces the following changes in order to change that:
##### common/interfaces.py
- Made changes in `start()` to accommodate ignoring PyRIC `nl80211` errors in the context of `--internetinterface` adapters  
- Refactored a part of `is_add_vif_required()` to make it more straightforward and easier to exclude `--internetinterface` and `--wpspbc_assoc_interface` from being considered as 'perfect_card' candidates  
- Fixed a variable name in `nm_unmanage()`

##### common/opmode.py
- Changed input arguments for `is_add_vif_required()`

##### pywifiphisher.py
- Made changes to catch relevant exceptions when calling `NetworkManager.unblock()`.  
There is a corner case in which this could cause a problem, only if an adapter is:
   - being used as an internet interface, and
   - does not support `nl80211`, and
   - is blocked   

  Added a message to warn the users that the interface has to be unblocked manually in such a scenario.