### PR TITLE
Automation of MITM attacks with a new argument

### DIFF
--- a/wifiphisher/common/interfaces.py
+++ b/wifiphisher/common/interfaces.py
@@ -365,7 +365,7 @@ class NetworkManager(object):
     @property
     def internet_access_enable(self):
         """
-        Return whether the -iI option is used
+        Return whether an interface will be used to provide Internet access
 
         :param self: A NetworkManager object
         :type self: NetworkManager

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -154,6 +154,13 @@ class OpMode(object):
                         '] --deauth-channels (-dC) requires channels in range 1-14.'
                     )
 
+        # if both args.mitminterface and args.internetinterface are provided, the
+        # former takes precedence and the latter gets overwritten.
+        if args.mitminterface and args.internetinterface:
+            print(('[' + constants.O + '!' + constants.W +
+                  '] using  both --mitminterface (-mI) and --internetinterface (-iI)'
+                  ' is redundant. Ignoring --internetinterface (-iI).'))
+
     def set_opmode(self, args, network_manager):
         """
         Sets the operation mode.

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -154,9 +154,12 @@ class OpMode(object):
                         '] --deauth-channels (-dC) requires channels in range 1-14.'
                     )
 
-        # if both args.mitminterface and args.internetinterface are provided, the
+        # If both args.mitminterface and args.internetinterface are provided, the
         # former takes precedence and the latter gets overwritten.
-        if args.internetinterface and args.mitminterface == "handledAsInternetInterface":
+        # We have ensured that if that is the case, then args.mitminterface will be
+        # overwritten with the value of args.internetinterface, whereas if no 
+        # args.internetinterface was provided, args.mitminterface will be set to a specific string.
+        if args.mitminterface and args.mitminterface != "handledAsInternetInterface":
             print(('[' + constants.O + '!' + constants.W +
                   '] Using  both --mitminterface (-mI) and --internetinterface (-iI)'
                   ' is redundant. Ignoring --internetinterface (-iI).'))

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -156,9 +156,9 @@ class OpMode(object):
 
         # if both args.mitminterface and args.internetinterface are provided, the
         # former takes precedence and the latter gets overwritten.
-        if args.mitminterface and args.internetinterface:
+        if args.internetinterface and args.mitminterface == "handledAsInternetInterface":
             print(('[' + constants.O + '!' + constants.W +
-                  '] using  both --mitminterface (-mI) and --internetinterface (-iI)'
+                  '] Using  both --mitminterface (-mI) and --internetinterface (-iI)'
                   ' is redundant. Ignoring --internetinterface (-iI).'))
 
     def set_opmode(self, args, network_manager):

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -82,10 +82,10 @@ def parse_args():
         help=("Specify the interface(s) that will have their connection protected (i.e. NetworkManager will be prevented from controlling them). " +
               "Example: -pI wlan1 wlan2"))
     parser.add_argument(
-        "-m",
+        "-mI",
         "--mitminterface",
         help=("Choose an interface that is connected on the Internet in order to perform a MITM attack. All other interfaces will be protected." +
-              "Example: -m wlan1"))
+              "Example: -mI wlan1"))
 
     # MAC address randomization
     parser.add_argument(
@@ -430,15 +430,15 @@ class WifiphisherEngine:
         try:
             if self.opmode.internet_sharing_enabled():
                 self.network_manager.internet_access_enable = True
-                # Set up an automatic MITM attack if `-m/--mitminterface` is present. 
+                # Set up an automatic MITM attack if `-mI/--mitminterface` is present. 
                 #
                 # We are already handling the chosen interface as an internetInterface.
                 # Here we are also protecting the rest of the detected interfaces.
                 #  (i.e. prevent NetworkManager from managing them)
                 if args.mitminterface:
-                    restoftheinterfaces=interfaces.NetworkManager._name_to_object.items()
-                    for interface in restoftheinterfaces.remove(args.mitminterface):
-                        self.network_manager.nm_unmanage(interface)
+                    for interface in self.network_manager._name_to_object:
+                        if interface != args.mitminterface:
+                          self.network_manager.nm_unmanage(interface)
                 if self.network_manager.is_interface_valid(
                         args.internetinterface, "internet"):
                     internet_interface = args.internetinterface

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -410,10 +410,12 @@ class WifiphisherEngine:
             phishinghttp.credential_log_path = args.credential_log_path
 
         # Handle the chosen interface as an internetInterface in order to 
-        # leverage existing functionality. 
-        # In case `--internetinterface` is also used it will be overwritten silently.
+        # leverage existing functionality.
+        # In case `--internetinterface` is also used it will be overwritten with a warning.
+        # Manually set mitmInterface to a specific string to account for further checks.
         if args.mitminterface:
             args.internetinterface = args.mitminterface
+            args.mitminterface = "handledAsInternetInterface"
         # Initialize the operation mode manager
         self.opmode.initialize(args)
         # Set operation mode
@@ -430,14 +432,14 @@ class WifiphisherEngine:
         try:
             if self.opmode.internet_sharing_enabled():
                 self.network_manager.internet_access_enable = True
-                # Set up an automatic MITM attack if `-mI/--mitminterface` is present. 
+                # Set up an automatic MITM attack if `-mI/--mitminterface` was already present.
                 #
                 # We are already handling the chosen interface as an internetInterface.
                 # Here we are also protecting the rest of the detected interfaces.
                 #  (i.e. prevent NetworkManager from managing them)
-                if args.mitminterface:
+                if args.mitminterface == "handledAsInternetInterface":
                     for interface in self.network_manager._name_to_object:
-                        if interface != args.mitminterface:
+                        if interface != args.internetinterface:
                           self.network_manager.nm_unmanage(interface)
                 if self.network_manager.is_interface_valid(
                         args.internetinterface, "internet"):

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -412,10 +412,21 @@ class WifiphisherEngine:
         # Handle the chosen interface as an internetInterface in order to 
         # leverage existing functionality.
         # In case `--internetinterface` is also used it will be overwritten with a warning.
-        # Manually set mitmInterface to a specific string to account for further checks.
+        #
+        # There are two cases for a provided args.mitminterface:
+        #   - In case args.internetinterface is also provided, swap their values so that we can
+        #     leverage args.internetinterface functionality but at the same time keep the fact that
+        #     it was provided as an argument, in order to be able to warn the user. 
+        #
+        #   - In case no args.internetinterface is provided, manually set args.mitminterface to a 
+        #     specific string to account for further checks.
         if args.mitminterface:
-            args.internetinterface = args.mitminterface
-            args.mitminterface = "handledAsInternetInterface"
+            if args.internetinterface:
+                args.internetinterface, args.mitminterface = args.mitminterface, args.internetinterface
+            else:
+                args.internetinterface = args.mitminterface
+                args.mitminterface = "handledAsInternetInterface"
+
         # Initialize the operation mode manager
         self.opmode.initialize(args)
         # Set operation mode
@@ -437,7 +448,9 @@ class WifiphisherEngine:
                 # We are already handling the chosen interface as an internetInterface.
                 # Here we are also protecting the rest of the detected interfaces.
                 #  (i.e. prevent NetworkManager from managing them)
-                if args.mitminterface == "handledAsInternetInterface":
+                # The value of args.mitminterface does not concern us, unless empty. We will be performing
+                # all operations using args.internetinterface instead.
+                if args.mitminterface:
                     for interface in self.network_manager._name_to_object:
                         if interface != args.internetinterface:
                           self.network_manager.nm_unmanage(interface)


### PR DESCRIPTION
This PR introduces a new argument (`-m/--mitminterface`) that provides the functionality of automating an active man-in-the-middle attack with internet sharing, using an interface of the users' choice. 

These changes could be considered as a wrapper for the automation of an attack, as they simply leverage existing functionality and operations previously set up for the usage of internet interfaces. This is achieved by "relabeling" the interface given in the `mitm` argument as an `internetinterface`.

In case both the `--mitminterface` and `--internetinterface` arguments are used, the latter gets overwritten silently. This could be changed depending on the behaviour that we want (e.g. warning the user at startup).

An equivalent of using `-m` could be using argument `-iI` in conjunction with  `-pI` along with others. 

(I also removed an unnecessary `pass` as mentioned in a [previous PR comment](https://github.com/wifiphisher/wifiphisher/pull/1344#discussion_r438933211)) 
