### PR TITLE
Fix WiFi Connect's OS Detection issue

### DIFF
--- a/wifiphisher/data/phishing-pages/wifi_connect/html/index.html
+++ b/wifiphisher/data/phishing-pages/wifi_connect/html/index.html
@@ -201,7 +201,7 @@
             document.write("<link rel='stylesheet' href='/static/style.css'>");
             document.write("<link href='/static/opensans.css' rel='stylesheet' type='text/css'>");
         }
-        else if (resolvedOs = "iOS") {
+        else if (resolvedOs == "iOS") {
             document.write("<link rel='stylesheet' href='/static/ios.css'>");
         }
         else {


### PR DESCRIPTION
Javascript from the WiFI Connect Plugin presents the iOS page independent of the OS used. This commit fixes this.