### PR TITLE
add --noextensionsinterface (-nEI) + checks if interface exists 

### DIFF
--- a/wifiphisher/common/extensions.py
+++ b/wifiphisher/common/extensions.py
@@ -143,6 +143,8 @@ class ExtensionManager(object):
         :rtype: None
         .. note: The channel range is between 1 to 13
         """
+        if not self._interface:
+            return
 
         # set the current channel to the ap channel
         self._nm.set_interface_channel(self._interface,
@@ -182,6 +184,8 @@ class ExtensionManager(object):
         """
 
         self._interface = interface
+        if not self._interface:
+            return
         self._socket = linux.L2Socket(iface=self._interface)
 
     def set_extensions(self, extensions):
@@ -363,7 +367,8 @@ class ExtensionManager(object):
         :return: None
         :rtype: None
         """
-
+        if not self._interface:
+            return
         # continue to find clients until told otherwise
         dot11.sniff(
             iface=self._interface,

--- a/wifiphisher/common/opmode.py
+++ b/wifiphisher/common/opmode.py
@@ -84,10 +84,11 @@ class OpMode(object):
 
         if ((args.extensionsinterface and not args.apinterface) or
                 (not args.extensionsinterface and args.apinterface)) and \
-                not (args.noextensions and args.apinterface):
+                not (args.noextensions and args.apinterface) and \
+                not args.noextensionsinterface:
             sys.exit('[' + constants.R + '-' + constants.W +
                      '] --apinterface (-aI) and --extensionsinterface (-eI)'
-                     '(or --noextensions (-nE)) are used in conjuction.')
+                     '(or --noextensions (-nE), or --noextensionsinterface (-nEI)) are used in conjuction.')
 
         if args.noextensions and args.extensionsinterface:
             sys.exit('[' + constants.R + '-' + constants.W +

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -67,8 +67,9 @@ def parse_args():
     parser.add_argument(
         "-nEI",
         "--noextensionsinterface",
-        help=("Do not choose an interface that supports monitor mode. " + 
-             "Only use if you only use extensions that does not require an interface with monitor mode !"))
+        help=("Bypass required interface that supports monitor mode. " + 
+             "Only use if you only use extensions that does not require an interface with monitor mode !"),
+	action='store_true')
     parser.add_argument(
         "-aI",
         "--apinterface",
@@ -482,15 +483,18 @@ class WifiphisherEngine:
                     logger.info("Selecting %s interface for WPS association",
                                 args.wpspbc_assoc_interface)
             if self.opmode.extensions_enabled():
-                if args.extensionsinterface and args.apinterface:
-                    if self.network_manager.is_interface_valid(
-                            args.extensionsinterface, "monitor"):
-                        mon_iface = args.extensionsinterface
+                if (args.extensionsinterface or args.noextensionsinterface) or args.apinterface:
+                    if not args.noextensionsinterface:
+                        if self.network_manager.is_interface_valid(
+                                args.extensionsinterface, "monitor"):
+                            mon_iface = args.extensionsinterface
                         self.network_manager.unblock_interface(mon_iface)
+                    else:
+                        mon_iface=None
                     if self.network_manager.is_interface_valid(
                             args.apinterface, "AP"):
                         ap_iface = args.apinterface
-                elif not args.noextensionsinterface:
+                else:
                     mon_iface, ap_iface = self.network_manager.get_interface_automatically(
                     )
                 # display selected interfaces to the user
@@ -502,7 +506,7 @@ class WifiphisherEngine:
                     "attack\n[{0}+{1}] Selecting {0}{3}{1} interface for creating the "
                     "rogue Access Point").format(G, W, mon_iface, ap_iface))
 
-            if not self.opmode.extensions_enabled():
+            if  not self.opmode.extensions_enabled():
                 if args.apinterface:
                     if self.network_manager.is_interface_valid(
                             args.apinterface, "AP"):
@@ -526,7 +530,7 @@ class WifiphisherEngine:
                         ap_iface, new_mac))
                     print("[{0}+{1}] Changing {2} MAC addr (BSSID) to {3}".format(
                         G, W, ap_iface, new_mac))
-                    if mon_iface != ap_iface:
+                    if mon_iface and mon_iface != ap_iface:
                         new_mac = self.network_manager.set_interface_mac(mon_iface,
                                              args.mac_extensions_interface)
                         logger.info("Changing {} MAC address to {}".format(
@@ -539,9 +543,10 @@ class WifiphisherEngine:
             # make sure interfaces are not blocked
             logger.info("Unblocking interfaces")
             self.network_manager.unblock_interface(ap_iface)
-            self.network_manager.unblock_interface(mon_iface)
+            if mon_iface:
+                self.network_manager.unblock_interface(mon_iface)
             # set monitor mode only when --essid is not given
-            if self.opmode.extensions_enabled() or args.essid is None:
+            if (self.opmode.extensions_enabled() or args.essid is None) and mon_iface:
                 self.network_manager.set_interface_mode(mon_iface, "monitor")
         except (interfaces.InvalidInterfaceError,
                 interfaces.InterfaceCantBeFoundError,
@@ -712,9 +717,9 @@ class WifiphisherEngine:
                 'APs': APs_context,
                 'args': args
             }
-
-            self.network_manager.up_interface(mon_iface)
-            self.em.set_interface(mon_iface)
+            if mon_iface:
+                self.network_manager.up_interface(mon_iface)
+                self.em.set_interface(mon_iface)
             extensions = DEFAULT_EXTENSIONS
             if args.lure10_exploit:
                 extensions.append(LURE10_EXTENSION)

--- a/wifiphisher/pywifiphisher.py
+++ b/wifiphisher/pywifiphisher.py
@@ -65,6 +65,11 @@ def parse_args():
         help=("Manually choose an interface that supports monitor mode for " +
               "deauthenticating the victims. " + "Example: -eI wlan1"))
     parser.add_argument(
+        "-nEI",
+        "--noextensionsinterface",
+        help=("Do not choose an interface that supports monitor mode. " + 
+             "Only use if you only use extensions that does not require an interface with monitor mode !"))
+    parser.add_argument(
         "-aI",
         "--apinterface",
         type=opmode.validate_ap_interface,
@@ -485,7 +490,7 @@ class WifiphisherEngine:
                     if self.network_manager.is_interface_valid(
                             args.apinterface, "AP"):
                         ap_iface = args.apinterface
-                else:
+                elif not args.noextensionsinterface:
                     mon_iface, ap_iface = self.network_manager.get_interface_automatically(
                     )
                 # display selected interfaces to the user


### PR DESCRIPTION
allow user to use extensions without specifying an interface instead of erroring out, so they can use extensions that dont require an interface like --handshake-capture
also add checks in extensions.py so the manager dont crash if an extension tries to do something with the None interface


(add --noextensionsinterface (-nEI) + checks if monitor interface exists in pywifiphisher.py and extensions.py)